### PR TITLE
Removing subsort KItem ::= Type to improve parsing times.

### DIFF
--- a/cil-semantics/cil-exp.k
+++ b/cil-semantics/cil-exp.k
@@ -218,7 +218,7 @@ module CIL-EXP
 
   syntax KItem ::= "noLeftValueConversion"
 
-  syntax KItem ::= Type [avoid]
+  //syntax KItem ::= Type [avoid]
 
   rule I:Int => norm(int, I)
 

--- a/cil-semantics/cil-syntax.k
+++ b/cil-semantics/cil-syntax.k
@@ -234,8 +234,8 @@ module CIL-SYNTAX
    */
   /* C identifiers */
   /* regular expression for tokens representing C identifiers */
-  syntax CId ::= Token{[\$A-Za-z\_][\$A-Za-z\_0-9]*}    [onlyLabel]
-               | Token{"main"}
+  syntax CId ::= Token{[\$A-Za-z\_][\$A-Za-z\_0-9]*}    [notInRules, regex("(?<![\\$A-Za-z\\_])[A-Za-z\\_][\\$A-Za-z0-9\\_]*")]
+               | "main"
   syntax CIds ::= List{CId, ","}
 
 


### PR DESCRIPTION
@dwightguth Please run the tests for this pull request.
I've made some optimizations that should improve the parsing times considerably, and I want to see if they are safe.