### PR TITLE
remove nailgun from make file (too tricky to set up dependencies)

### DIFF
--- a/tests/gcc-torture/Makefile
+++ b/tests/gcc-torture/Makefile
@@ -10,6 +10,7 @@ CHECK_RESULT_COMPILE = if [ $$? -eq 0 ] ; then echo "passed $<"; mv $@.tmp.out $
 CHECK_RESULT_RUN = if [ $$? -eq 0 ] ; then echo "passed $<"; mv $@.tmp $@; else echo "failed $<"; cat $@.tmp; fi
 
 .PHONY: test clean reference
+.PRECIOUS: %.kcc %.out
 
 test: ${TEST_RESULTS}
 


### PR DESCRIPTION
@chathhorn please review

I am moving this code out of the Makefile because it has run into issues dealing with starting and stopping the server that are not easy to deal with using Make. The correct way to use the makefile to run with nailgun is to start the server, set the K_NAILGUN env variable, and then run `make`.
