### PR TITLE
remove hacky version checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ fast: $(DIST_DIR)/lib/libc.so $(DIST_DIR)/c11-kompiled/c11-kompiled/context.bin
 
 check-vars:
 	@if ! ocaml -version > /dev/null 2>&1; then echo "ERROR: You don't seem to have ocaml installed.  You need to install this before continuing.  Please see INSTALL.md for more information."; false; fi
-	@if ! gcc-4.9 -v > /dev/null 2>&1; then if ! clang -v 2>&1 | grep "3.5" > /dev/null; then echo "ERROR: You don't seem to have gcc 4.9 or clang 3.5 installed.  You need to install this before continuing.  Please see INSTALL.md for more information."; false; fi fi
+	@if ! gcc -v > /dev/null 2>&1; then if ! clang -v > /dev/null 2>&1; then echo "ERROR: You don't seem to have gcc or clang installed.  You need to install this before continuing.  Please see INSTALL.md for more information."; false; fi fi
 	@if ! kompile --version > /dev/null 2>&1; then echo "ERROR: You don't seem to have kompile installed.  You need to install this before continuing.  Please see INSTALL.md for more information."; false; fi
 	@if ! krun --version > /dev/null 2>&1; then echo "ERROR: You don't seem to have krun installed.  You need to install this before continuing.  Please see INSTALL.md for more information."; false; fi
 	@perl $(SCRIPTS_DIR)/checkForModules.pl

--- a/scripts/kcc
+++ b/scripts/kcc
@@ -354,7 +354,7 @@ sub preprocess {
      my ($output, $inputFile) = (@_);
 
      my $directoryname = dirname($inputFile);
-     system("which gcc-4.9 > /dev/null 2>&1");
+     system("which gca > /dev/null 2>&1");
      my $pp;
      if ($? >> 8 == 0) {
           $pp = "gcc";

--- a/scripts/kcc
+++ b/scripts/kcc
@@ -357,7 +357,7 @@ sub preprocess {
      system("which gcc-4.9 > /dev/null 2>&1");
      my $pp;
      if ($? >> 8 == 0) {
-          $pp = "gcc-4.9";
+          $pp = "gcc";
      } else {
           # no gcc, try clang
           $pp = "clang";

--- a/tests/native/Makefile
+++ b/tests/native/Makefile
@@ -19,7 +19,7 @@ reference: ${REFERENCE_TEST_RESULTS}
 comparison: ${TEST_COMPARISON}
 
 libtest.so: libtest.c
-	gcc-4.9 -shared -std=c11 -fPIC -o $@ $<
+	gcc -shared -std=c11 -fPIC -o $@ $<
 
 %.out: %.kcc
 	@echo -n "Running $<... "
@@ -31,7 +31,7 @@ libtest.so: libtest.c
 
 %.gcc: %.c libtest.so
 	@echo -n "Compiling $< (reference)... "
-	@gcc-4.9 -std=c11 -o $@ $< -ldl -lm ./libtest.so > $@.tmp.out 2>&1; ${CHECK_RESULT_COMPILE}
+	@gcc -std=c11 -o $@ $< -ldl -lm ./libtest.so > $@.tmp.out 2>&1; ${CHECK_RESULT_COMPILE}
 
 %.ref: %.gcc
 	@echo -n "Running $<... "

--- a/tests/unit-pass/Makefile
+++ b/tests/unit-pass/Makefile
@@ -32,11 +32,11 @@ comparison: ${TEST_COMPARISON}
 
 %-link1.gcc: %-link1.c %-link2.c
 	@echo -n "Compiling $^ (reference)... "
-	@gcc-4.9 -std=c11 -o $@ $^ -lm > $@.tmp.out 2>&1; ${CHECK_RESULT_COMPILE}
+	@gcc -std=c11 -o $@ $^ -lm > $@.tmp.out 2>&1; ${CHECK_RESULT_COMPILE}
 
 %.gcc: %.c
 	@echo -n "Compiling $< (reference)... "
-	@gcc-4.9 -std=c11 -o $@ $< -lm > $@.tmp.out 2>&1; ${CHECK_RESULT_COMPILE}
+	@gcc -std=c11 -o $@ $< -lm > $@.tmp.out 2>&1; ${CHECK_RESULT_COMPILE}
 
 %.ref: %.gcc
 	@echo -n "Running $<... "


### PR DESCRIPTION
If you have a compiler that supports -std=c11 but doesn't actually
support c11 sufficiently, on your own head be it.

@andreistefanescu can you try this and if it fixes your problem, merge?