### PR TITLE
remove --kore flags to update to latest K master

### DIFF
--- a/scripts/kcc
+++ b/scripts/kcc
@@ -293,7 +293,7 @@ sub main {
           my @cmd = ('-d', catfile($profileDirectory, "c11-kompiled"), 
                   '-cARGV=`#argv`(.KList) ', "-pARGV=$printf",
                   '-w', 'none', '--parser', 'cat', $programConfFile,
-                  '--kore', '--exit-code', "<result-value> _:Int </result-value>",
+                  '--exit-code', "<result-value> _:Int </result-value>",
                   $options, "-pOPTIONS=$printf",
                   '--output-file', $oval, '--ocaml-compile', '--ocaml-dump-exit-code', '139',
                   '--ocaml-serialize-config', '$PGM'
@@ -441,7 +441,6 @@ sub getKRunCommand {
      my ($output, $obj1, $obj2, $obj3, $obj4, $src, $link) = (@_);
 
      my @krun_args = (
-          '--kore',
           '--output', 'kast', 
           '--output-file', $output,
           '-d', $TRANS_DEF,

--- a/scripts/program-runner
+++ b/scripts/program-runner
@@ -57,7 +57,7 @@ sub main {
       my $argv = reduce { our ($a, $b); "`_List_`($a,$b)" } (map {qq|`ListItem`(#token($_, "String"))|} (map {quote(backslash(quote(backslash($_))))} ($0, @ARGV)));
 
       my @cmd = ('--output', 'kast', '-d', $EXEC_DEF, "-cARGV=$argv", '-pARGV=printf %s', '-w', 'none', '--parser',
-                 'cat', $fileInput, '--kore', '--exit-code', "<result-value> _:Int </result-value>");
+                 'cat', $fileInput, '--exit-code', "<result-value> _:Int </result-value>");
       my $options = '`.Set`(.KList)';
 
       if (defined $ENV{HELP}) {

--- a/semantics/Makefile
+++ b/semantics/Makefile
@@ -19,19 +19,19 @@ default: fast
 
 c11-translation-kompiled/c11-translation-kompiled/def.$(EXTENSION): $(C11_TRANSLATION_FILES)
 	@echo "Kompiling the static C semantics..."
-	$(KOMPILE) --backend ocaml --kore --non-strict --smt none c11-translation.k -d "c11-translation-kompiled" -w all -v --debug
+	$(KOMPILE) --backend ocaml --non-strict --smt none c11-translation.k -d "c11-translation-kompiled" -w all -v --debug
 
 c11-kompiled/c11-kompiled/def.$(EXTENSION): $(C11_FILES)
 	@echo "Kompiling the dynamic C semantics..."
-	$(KOMPILE) --backend ocaml --kore --non-strict --smt none c11.k -d "c11-kompiled" -w all -v --transition "interpRule" --debug
+	$(KOMPILE) --backend ocaml --non-strict --smt none c11.k -d "c11-kompiled" -w all -v --transition "interpRule" --debug
 
 c11-nd-kompiled/c11-nd-kompiled/def.$(EXTENSION): $(C11_FILES)
 	@echo "Kompiling the dynamic C semantics with expression sequencing non-determinism..."
-	$(KOMPILE) --backend ocaml --kore --non-strict --smt none c11.k -d "c11-nd-kompiled" --transition "observable ndtrans" --superheat "ndheat" --supercool "ndlocal"
+	$(KOMPILE) --backend ocaml --non-strict --smt none c11.k -d "c11-nd-kompiled" --transition "observable ndtrans" --superheat "ndheat" --supercool "ndlocal"
 
 c11-nd-thread-kompiled/c11-nd-thread-kompiled/def.$(EXTENSION): $(C11_FILES)
 	@echo "Kompiling the dynamic C semantics with thread-interleaving non-determinism..."
-	$(KOMPILE) --backend ocaml --kore --non-strict --smt none c11.k -d "c11-nd-thread-kompiled" --transition "observable ndtrans ndthread"
+	$(KOMPILE) --backend ocaml --non-strict --smt none c11.k -d "c11-nd-thread-kompiled" --transition "observable ndtrans ndthread"
 
 all: fast nd thread
 


### PR DESCRIPTION
Not going to ask for review on this because it fixes the master after the merge of kframework/k#1819. But @chathhorn feel free to take a look and let me know if you see a problem.