### PR TITLE
remove noncommercial from license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -17,10 +17,12 @@ Developed by:
       * University Alexandru-Ioan Cuza, Romania (https://fmse.info.uaic.ro)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to use, 
-copy, modify, merge, publish, and/or distribute the Software in a
-non-commercial setting, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
 
     * Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimers.
@@ -28,9 +30,6 @@ furnished to do so, subject to the following conditions:
     * Redistributions in binary form must reproduce the above copyright notice,
       this list of conditions and the following disclaimers in the
       documentation and/or other materials provided with the distribution.
-
-    * The Software may not be used in any manner that is primarily intended for
-      or directed toward commercial advantage or private monetary compensation.
 
     * Neither the names of the K Team, Runtime Verification, the University of
       Illinois at Urbana-Champaign, the University Alexandru-Ioan Cuza, nor 


### PR DESCRIPTION
@grosu please review

@ellisonch FYI. We decided to go a different route with the licensing after all. There is definitely some potential for lost revenue down this new path, but if nothing else we should be able to make money for the foreseeable future with the current proprietary components we have, and we have discussed plans to make a few less-critical components also proprietary.