### PR TITLE
fix confluence issue with storage class specifiers on parameters

### DIFF
--- a/semantics/language/translation/decl/global.k
+++ b/semantics/language/translation/decl/global.k
@@ -172,6 +172,7 @@ module C-DECL-GLOBAL
           ...</k>
           <curr-scope> prototypeScope </curr-scope>
           requires notBool validPrototypeStorageClass(T)
+               andBool notBool isVoidType(T)
           [structural]
      rule <k> (.K => UNDEF("TDG6",
                "void parameter appears with a storage class specifier.",


### PR DESCRIPTION
@chathhorn please review. It's a little ambiguous whether this is a correct change because the constraint violation says that a parameter declaration shall not have a storage class specifier other than register and it's not 100% clear whether `(void)` counts as a parameter declaration in that sense. If yes, then this change is technically incorrect. But I think since we report an error either way it should probably be fine, and I like the advantage of having confluent rules for this case because it fixes the case where tests can fail based on the order of rules in the compiled definition.