### PR TITLE
ignore windows versus linux line breaks in test outputs

### DIFF
--- a/tests/unit-pass/Makefile
+++ b/tests/unit-pass/Makefile
@@ -48,7 +48,7 @@ compile: ${KCC_COMPILED_TESTS}
 
 %.cmp: %.out %.ref
 	@echo -n "Comparing $^... "
-	@diff $^ > $@.tmp 2>&1; ${CHECK_RESULT_RUN}
+	@diff --strip-trailing-cr $^ > $@.tmp 2>&1; ${CHECK_RESULT_RUN}
 
 clean:
 	rm -rf *.out *.kcc *.tmp *.gcc *.ref *.cmp


### PR DESCRIPTION
@pdaian please review

This is the first of two diffs that hopefully should fix the windows build.