### PR TITLE
composite types need not have the same name for function parameters

### DIFF
--- a/semantics/language/common/typing/compatibility.k
+++ b/semantics/language/common/typing/compatibility.k
@@ -300,7 +300,7 @@ module C-TYPING-COMPATIBILITY
 
      rule compositeType(
                typedDeclaration(T:Type, X:CId),
-               typedDeclaration(T':Type, X:CId))
+               typedDeclaration(T':Type, _:CId))
           => typedDeclaration(compositeType(T, T'), X)
      rule compositeType(
                T:Type,


### PR DESCRIPTION
@chathhorn please review

Fixes runtimeverification/rv-match#95