### PR TITLE
Stack size checking for RV-Match, part 1

### DIFF
--- a/rv-match/x86-gcc-limited-libc/semantics/settings.k
+++ b/rv-match/x86-gcc-limited-libc/semantics/settings.k
@@ -53,5 +53,7 @@ module C-SETTINGS
      rule isErrorRecovery => true
      rule hasLint => true
 
+     rule cfg:stackSize(_, _) => 0
+
 endmodule
 

--- a/scripts/kcc
+++ b/scripts/kcc
@@ -169,6 +169,7 @@ my $spec = q(#
       -flint			Generate lint errors for potentially undesirable behaviors.*
       -Wlint			[ditto]
       -fheap-size=<size>	Used with -flint to detect dynamic memory overflow.*
+      -fstack-size=<size>	Used with -flint to detect stack overflow.*
       -frecover-all-errors	Recover from fatal errors that would normally cause an application to crash.
       				WARNING: This can change the semantics of tools like autoconf which analyze
       				the exit code of the compiler to trigger unexpected or undesirable results.

--- a/scripts/kcc
+++ b/scripts/kcc
@@ -328,18 +328,32 @@ sub main {
           }
           if ($args->{'-flint'} || $args->{'-Wlint'}) {
                push(@options, "`LINT`(.KList)");
-               my $size;
+               my $heapSize;
                if ($args->{'-fheap-size='}) {
-                    $size = `echo $args->{'-fheap-size='} | sed -e 's/[Tt]/kg/i;s/[Gg]/km/i;s/[Mm]/kk/i;s/k/*1024/ig' | bc`;
-                    chop($size);
+                    $heapSize = `echo $args->{'-fheap-size='} | sed -e 's/[Tt]/kg/i;s/[Gg]/km/i;s/[Mm]/kk/i;s/k/*1024/ig' | bc`;
+                    chop($heapSize);
                } else {
-                    $size = 1024 * 1024 * 1024;
+                    $heapSize = 1024 * 1024 * 1024;
                }
-               $size = quote(backslash($size));
+               $heapSize = quote(backslash($heapSize));
                if ($cygwin) {
-                    $size = backslash($size);
+                    $heapSize = backslash($heapSize);
                }
-               push(@options, "`HEAP`(#token($size, $quoteInt))");
+               my $stackSize;
+               if ($args->{'-fstack-size='}) {
+                    $stackSize = `echo $args->{'-fstack-size='} | sed -e 's/[Tt]/kg/i;s/[Gg]/km/i;s/[Mm]/kk/i;s/k/*1024/ig' | bc`;
+                    chop($stackSize);
+               } else {
+                    $stackSize = `echo \`ulimit -s\``;
+                    chop($stackSize);
+                    $stackSize = $stackSize * 1024; # result was in kb
+               }
+               $stackSize = quote(backslash($stackSize));
+               if ($cygwin) {
+                    $stackSize = backslash($stackSize);
+               }
+               push(@options, "`HEAP`(#token($heapSize, $quoteInt))");
+               push(@options, "`STACK`(#token($stackSize, $quoteInt))");
           }
           my $opts = makeSet(@options);
 

--- a/semantics/language/common/compat.k
+++ b/semantics/language/common/compat.k
@@ -58,6 +58,8 @@ module COMPAT-SYNTAX
                     | lookup(Map, K) [function]
 
      syntax Bool ::= isKItem(K) [function]
+
+     syntax Int ::= ceilDiv(Int, Int) [function]
 endmodule
 
 module COMPAT
@@ -232,4 +234,6 @@ module COMPAT
 
      rule isKItem(_:KItem) => true
      rule isKItem(_) => false [owise]
+
+     rule ceilDiv(X:Int, Y:Int) => (X +Int Y -Int 1) /Int Y
 endmodule

--- a/semantics/language/common/compat.k
+++ b/semantics/language/common/compat.k
@@ -60,6 +60,7 @@ module COMPAT-SYNTAX
      syntax Bool ::= isKItem(K) [function]
 
      syntax Int ::= ceilDiv(Int, Int) [function]
+     syntax List ::= mapList(List, K) [function]
 endmodule
 
 module COMPAT
@@ -176,9 +177,12 @@ module COMPAT
      rule toKRList'(.SubKRList) => .K
           [structural]
 
-     rule reverseList(.List) => .List
-     rule reverseList(ListItem(K:K) L:List)
-          => reverseList(L:List) ListItem(K:K)
+     syntax List ::= reverseAppendList(List, List) [function]
+     rule reverseAppendList(.List, L::List) => L
+     rule reverseAppendList(ListItem(K:K) L::List, L2::List)
+          => reverseAppendList(L, ListItem(K) L2)
+
+     rule reverseList(L::List) => reverseAppendList(L, .List)
 
      rule listToK(ListItem(K:K) L:List) => K ~> listToK(L)
      rule listToK(.List) => .K
@@ -236,4 +240,7 @@ module COMPAT
      rule isKItem(_) => false [owise]
 
      rule ceilDiv(X:Int, Y:Int) => (X +Int Y -Int 1) /Int Y
+
+     rule mapList(ListItem(K:K) L:List, #klabel(Lbl:KLabel)) => ListItem(Lbl(K)) mapList(L, #klabel(Lbl))
+     rule mapList(.List, _) => .List
 endmodule

--- a/semantics/language/common/dynamic.k
+++ b/semantics/language/common/dynamic.k
@@ -80,8 +80,8 @@ module C-DYNAMIC-SYNTAX
      // these are semantic
      syntax KItem ::= reval(K)
 
-     // Function id, def return type, def params, body.
-     syntax RValue ::= functionObject(CId, Type, K)
+     // Function id, def return type, def params, local declarations, body.
+     syntax RValue ::= functionObject(CId, Type, List, K)
 
      syntax KResult ::= initValue(CId, Type, K)
      syntax KItem ::= allowInit(K)

--- a/semantics/language/common/memory/writing.k
+++ b/semantics/language/common/memory/writing.k
@@ -283,7 +283,7 @@ module C-MEMORY-WRITING
           dataList(ListItem(piece(N:Bits, PieceLen:Int)) Rest:List),
                T:Type, Len:Int, L:List)
           => #splitStructBytes(dataList(Rest), T, Len -Int 1,
-               L ListItem(piece(N, PieceLen)))
+               ListItem(piece(N, PieceLen)) L)
           requires PieceLen ==Int cfg:bitsPerByte
                andBool Len >Int 0
                andBool (notBool isPaddingOffset(byteSizeofType(T) -Int Len, getFieldInfo(T))
@@ -293,7 +293,7 @@ module C-MEMORY-WRITING
                T:Type, Len:Int, _:List)
           requires isPaddingOffset(byteSizeofType(T) -Int Len, getFieldInfo(T))
                andBool N =/=K unknown
-     rule #splitStructBytes(_, _, 0, L:List) => dataList(L)
+     rule #splitStructBytes(_, _, 0, L:List) => dataList(reverseList(L))
 
      syntax Bool ::= isPaddingOffset(Int, K) [function]
      rule isPaddingOffset(Offset:Int, fieldInfo(Decls:List, _, Types:Map, Offsets:Map))

--- a/semantics/language/common/settings.k
+++ b/semantics/language/common/settings.k
@@ -1,4 +1,5 @@
 module C-SETTINGS-SYNTAX
+     imports LIST 
      // S 6.2.5 p.35 i.15.  "The implementation shall define char to have the
      // same range, representation, and behavior as either signed char or
      // unsigned char.  37)... Irrespective of the choice made, char is a
@@ -43,6 +44,8 @@ module C-SETTINGS-SYNTAX
 
      syntax CValue ::= "cfg:intToPointer" "(" CValue "," Type ")" [function]
      syntax CValue ::= "cfg:pointerToInt" "(" CValue "," Type ")" [function]
+ 
+     syntax Int ::= "cfg:stackSize" "(" List "," List ")" [function]
 
      syntax Bool ::= "isErrorRecovery" [function]
                    | "hasLint" [function]

--- a/semantics/language/execution/configuration.k
+++ b/semantics/language/execution/configuration.k
@@ -66,6 +66,7 @@ module C-CONFIGURATION
 
      <thread-info color="yellow">
           <thread-status color="yellow"> .Map </thread-status>
+          <stack-depth> ListItem(0) </stack-depth>
           <mutexes color="yellow"> .Map </mutexes>
           <glocks color="yellow"> .Map </glocks>
      </thread-info>

--- a/semantics/language/execution/expr/function-call.k
+++ b/semantics/language/execution/expr/function-call.k
@@ -126,7 +126,7 @@ module C-EXPR-FUNCTION-CALL
                <curr-program-loc> CurrLoc::CabsLoc </curr-program-loc>
                (C:ControlDetailsCell => <control-details>... .Bag ...</control-details>)
           </control>
-          <stack-depth> ListItem(Old:Int) => ListItem(Old +Int cfg:stackSize(getParams(DefT), Locals)) ListItem(Old) ...</stack-depth>
+          <stack-depth> ListItem(Old:Int) => ListItem(Old +Int cfg:stackSize(mapList(L, #klabel(`type`)), Locals)) ListItem(Old) ...</stack-depth>
           requires areCompatible(CallT, toPrototype(DefT))
           [structural]
      rule (.K => UNDEF("EFNC1", "Attempt to call the function " +String

--- a/semantics/language/execution/expr/function-call.k
+++ b/semantics/language/execution/expr/function-call.k
@@ -11,6 +11,7 @@ module C-EXPR-FUNCTION-CALL
      imports C-SYNTAX
      imports C-TYPING-COMPATIBILITY-SYNTAX
      imports C-TYPING-SYNTAX
+     imports C-SETTINGS-SYNTAX
 
      imports C-CONFIGURATION
 
@@ -88,11 +89,14 @@ module C-EXPR-FUNCTION-CALL
      */
 
      syntax KItem ::= application(String, RValue, Type, List)
+     syntax KItem ::= "checkStackDepth"
+     rule checkStackDepth => .K
+          requires notBool hasLint
 
      /*@ This extra step is useful for putting the function name in the
         transition graph. */
      rule <k> application(Tu:String,
-                    functionObject(X:CId, DefT:Type, Blk:K),
+                    functionObject(X:CId, DefT:Type, Locals:List, Blk:K),
                     CallT:Type, L:List)
                ~> K:K
                => sequencePoint
@@ -100,6 +104,7 @@ module C-EXPR-FUNCTION-CALL
                ~> populateFromGlobal
                ~> bind(getParams(DefT), getParams(CallT), L)
                ~> sequencePoint
+               ~> checkStackDepth
                ~> Blk
           </k>
           <call-stack> .List => ListItem(
@@ -121,11 +126,12 @@ module C-EXPR-FUNCTION-CALL
                <curr-program-loc> CurrLoc::CabsLoc </curr-program-loc>
                (C:ControlDetailsCell => <control-details>... .Bag ...</control-details>)
           </control>
+          <stack-depth> ListItem(Old:Int) => ListItem(Old +Int cfg:stackSize(getParams(DefT), Locals)) ListItem(Old) ...</stack-depth>
           requires areCompatible(CallT, toPrototype(DefT))
           [structural]
      rule (.K => UNDEF("EFNC1", "Attempt to call the function " +String
           idToString(X) +String " through a pointer with incompatible type.", "6.5.2.2:9, J.2:1 item 41"))
-          ~> application(_, functionObject(X:CId, DefT:Type, _), CallT:Type, _)
+          ~> application(_, functionObject(X:CId, DefT:Type, _, _), CallT:Type, _)
           requires notBool areCompatible(CallT, toPrototype(DefT))
           [structural]
 

--- a/semantics/language/execution/io-buffered.k
+++ b/semantics/language/execution/io-buffered.k
@@ -27,7 +27,7 @@ module C-IO-BUFFERED
 
      imports C-CONFIGURATION
 
-     syntax KItem ::= bwrite(SymLoc, K)
+     syntax KItem ::= bwrite(SymLoc, List)
 
      syntax KItem ::=  writeBytes(SymLoc, List)
      rule <k> writeBytes(Loc::SymLoc, dataList(Bytes::List), T::Type)
@@ -65,9 +65,6 @@ module C-IO-BUFFERED
           => setModified(Loc, Size, K, M)
      rule setModified(_, _, .K, .Map) => .K
 
-
-     rule writeBytes(_, .List) => .K
-          [structural]
 
      syntax KItem ::= checkWrite(SymLoc, Type)
      syntax KItem ::= checkBounds(SymLoc, Int)
@@ -146,33 +143,38 @@ module C-IO-BUFFERED
                andBool (ThreadId =/=K getThreadId(Loc))
           [structural]
 
-     rule <k> writeBytes(loc(Base::SymBase, Offset::Int), ListItem(V::CValue) L::List) => writeBytes(loc(Base, Offset +Int 1), L) ...</k>
-          <buffer>... (.List => ListItem(bwrite(loc(Base, Offset), V))) </buffer>
+     rule <k> writeBytes(loc(Base::SymBase, Offset::Int), L::List) => .K ...</k>
+          <buffer>... (.List => ListItem(bwrite(loc(Base, Offset), L))) </buffer>
           [structural]
 
      rule <buffer>
-               (ListItem(bwrite(loc(Base::SymBase, Offset::Int), V:K)) => .List)
+               ListItem(bwrite(loc(Base::SymBase, (Offset::Int => Offset +Int 1)), (ListItem(V:K) => .List) _:List))
           ...</buffer>
           <mem>...
                Base |-> object(_, Len::Int, (Bytes::Map => Bytes[Offset <- V]), _)
           ...</mem>
           requires Offset <Int Len
           [structural]
+     rule <buffer> ListItem(bwrite(_, .List)) => .List ...</buffer>
 
      syntax List ::= #writeNativeByte(SymLoc, K) [function, hook(C_SEMANTICS.writeNativeByte), impure, canTakeSteps]
      rule <buffer>
-               ListItem(bwrite(Loc::SymLoc, V:K)) => #writeNativeByte(Loc, V)
+               ListItem(bwrite((Loc::SymLoc => Loc +bytes 1), ((ListItem(V:K) => #writeNativeByte(Loc, V)) _:List)))
           ...</buffer>
           requires isNativeLoc(Loc)
 
      syntax Set ::= locations(List) [function]
      rule locations(.List) => .Set
-     rule locations(ListItem(bwrite(Loc::SymLoc, _)) L::List)
-          => SetItem(Loc) locations(L)
+     rule locations(ListItem(bwrite(Loc::SymLoc, Bytes::List)) L::List)
+          => #locations(Loc, size(Bytes)) locations(L)
+     syntax Set ::= #locations(SymLoc, Int) [function]
+     rule #locations(Loc::SymLoc, I:Int) => SetItem(Loc) #locations(Loc +bytes 1, I -Int 1)
+          requires I >Int 0
+     rule #locations(Loc::SymLoc, 0) => .Set
 
      rule <k> readBytes(Loc::SymLoc, Size::Int, T::Type)
                => checkEffectiveType(T, getEffectiveType(Loc))
-               ~> readBytes-aux(Loc, Size, .List, T)
+               ~> readBytes-aux(Loc +bytes (Size -Int 1), Size, .List, T)
           ...</k>
           <thread-id> ThreadId::Int </thread-id>
           requires notBool ((isThreadDuration(Loc) orBool isAutoDuration(Loc))
@@ -220,7 +222,7 @@ module C-IO-BUFFERED
                => assertSeq(loc(Base, Offset), Locs)
                ~> assertInBounds(Offset, Len)
                ~> assertVolatile(ObjT, Offset, T)
-               ~> readBytes-aux(loc(Base, Offset) +bytes 1, Size -Int 1, Aux ListItem(V), T)
+               ~> readBytes-aux(loc(Base, Offset) +bytes -1, Size -Int 1, ListItem(V) Aux, T)
           ...</k>
           <mem>...
                Base |-> object(ObjT::Type, Len::Int, (_ Offset::Int |-> V:K), _)
@@ -233,7 +235,7 @@ module C-IO-BUFFERED
                => assertSeq(loc(Base, Offset), Locs)
                ~> assertInBounds(Offset, Len)
                ~> assertVolatile(ObjT, Offset, T)
-               ~> readBytes-aux(loc(Base, Offset) +bytes 1, Size -Int 1, Aux ListItem(V), T)
+               ~> readBytes-aux(loc(Base, Offset) +bytes -1, Size -Int 1, ListItem(V) Aux, T)
           ...</k>
           <mem>...
                Base |-> object(ObjT::Type, Len::Int, (_ Offset::Int |-> V:K), _)
@@ -246,7 +248,7 @@ module C-IO-BUFFERED
                => assertInBounds(Offset, Len)
                ~> assertVolatile(ObjT, Offset, T)
                ~> assertUninit(loc(Base, Offset))
-               ~> readBytes-aux(loc(Base, Offset) +bytes 1, Size -Int 1, Aux ListItem(getUninitializedBits(loc(Base, Offset), ObjT)), T)
+               ~> readBytes-aux(loc(Base, Offset) +bytes -1, Size -Int 1, ListItem(getUninitializedBits(loc(Base, Offset), ObjT)) Aux, T)
           ...</k>
           <mem>...
                Base |-> object(ObjT::Type, Len::Int,
@@ -315,7 +317,7 @@ module C-IO-BUFFERED
      syntax CValue ::= #readNativeByte(SymLoc, Int, Type) [function, hook(C_SEMANTICS.readNativeByte), impure, canTakeSteps]
      rule <k> readBytes-aux(Loc::SymLoc, Size::Int, Aux::List, T::Type)
                => assertSeq(Loc, Locs)
-               ~> readBytes-aux(Loc +bytes 1, Size -Int 1, Aux ListItem(#readNativeByte(Loc, size(Aux), T)), T)
+               ~> readBytes-aux(Loc +bytes -1, Size -Int 1, ListItem(#readNativeByte(Loc, size(Aux), T)) Aux, T)
           ...</k>
           <locs-written> Locs::List </locs-written>
           <buffer> Mem::List </buffer>

--- a/semantics/language/execution/stmt/return.k
+++ b/semantics/language/execution/stmt/return.k
@@ -105,6 +105,7 @@ module C-STMT-RETURN
                     ...</call-stack-frame>
                ) => .List
           ...</call-stack>
+          <stack-depth> ListItem(_) => .List ...</stack-depth>
           [structural]
 
 endmodule

--- a/semantics/language/translation/configuration.k
+++ b/semantics/language/translation/configuration.k
@@ -138,6 +138,7 @@ module C-CONFIGURATION
           </decl-type-holder>
      </init-calc>
      <curr-tu color="lightgray"> "" </curr-tu>
+     <curr-function> .K </curr-function>
      <curr-scope color="lightgray"> fileScope:Scope </curr-scope>
 </exec>
 

--- a/semantics/language/translation/env.k
+++ b/semantics/language/translation/env.k
@@ -5,6 +5,7 @@ module C-ENV-SYNTAX
 
      syntax KItem ::= addToEnv(CId, SymBase)
      syntax KItem ::= giveType(CId, Type)
+     syntax KItem ::= giveParamType(CId, Type)
      syntax KItem ::= addEnum(CId, Int)
      syntax KItem ::= "populateFromGlobal"
      syntax KItem ::= scope(Scope, K)
@@ -68,7 +69,12 @@ module C-ENV
           ...</k>
           <curr-scope> fileScope </curr-scope>
      rule <k> giveType(X:CId, T:Type)
-               => giveLocalType(X, tagRestrict(S, stripStorageSpecifiers(T)))
+               => giveLocalType(X, tagRestrict(S, stripStorageSpecifiers(T)), false)
+          ...</k>
+          <curr-scope> S:Scope </curr-scope>
+          requires S =/=K fileScope
+     rule <k> giveParamType(X:CId, T:Type)
+               => giveLocalType(X, tagRestrict(S, stripStorageSpecifiers(T)), true)
           ...</k>
           <curr-scope> S:Scope </curr-scope>
           requires S =/=K fileScope
@@ -80,15 +86,15 @@ module C-ENV
           <tu-id> Tu </tu-id>
           <gtypes> G:Map => G[X <- T] </gtypes>
 
-     syntax KItem ::= giveLocalType(K, Type)
-     rule <k> giveLocalType(X:CId, T:Type) => .K ...</k>
+     syntax KItem ::= giveLocalType(K, Type, Bool)
+     rule <k> giveLocalType(X:CId, T:Type, false) => .K ...</k>
           <curr-function> Base:SymBase </curr-function>
           <functions>... Base |-> functionObject(_, _, (_:List (.List => ListItem(T))), _) ...</functions>
           <types> L:Map => L[X <- T] </types>
-     rule <k> giveLocalType(X:CId, T:Type) => .K ...</k>
+     rule <k> giveLocalType(X:CId, T:Type, B:Bool) => .K ...</k>
           <curr-scope> S:Scope </curr-scope> 
           <types> L:Map => L[X <- T] </types>
-          requires getKLabel(S) =/=K #klabel(`blockScope`)
+          requires getKLabel(S) =/=K #klabel(`blockScope`) orBool B
 
      rule <k> scope(Scope:Scope, K:K)
               => pushLocals ~> K ~> popLocals ~> setScope(OldScope)

--- a/semantics/language/translation/env.k
+++ b/semantics/language/translation/env.k
@@ -82,8 +82,7 @@ module C-ENV
 
      syntax KItem ::= giveLocalType(K, Type)
      rule <k> giveLocalType(X:CId, T:Type) => .K ...</k>
-          <external-defs>... Fun |-> Base:SymBase ...</external-defs>
-          <curr-scope> blockScope(Fun:CId, _) </curr-scope>
+          <curr-function> Base:SymBase </curr-function>
           <functions>... Base |-> functionObject(_, _, (_:List (.List => ListItem(T))), _) ...</functions>
           <types> L:Map => L[X <- T] </types>
      rule <k> giveLocalType(X:CId, T:Type) => .K ...</k>

--- a/semantics/language/translation/env.k
+++ b/semantics/language/translation/env.k
@@ -82,7 +82,14 @@ module C-ENV
 
      syntax KItem ::= giveLocalType(K, Type)
      rule <k> giveLocalType(X:CId, T:Type) => .K ...</k>
+          <external-defs>... Fun |-> Base:SymBase ...</external-defs>
+          <curr-scope> blockScope(Fun:CId, _) </curr-scope>
+          <functions>... Base |-> functionObject(_, _, (_:List (.List => ListItem(T))), _) ...</functions>
           <types> L:Map => L[X <- T] </types>
+     rule <k> giveLocalType(X:CId, T:Type) => .K ...</k>
+          <curr-scope> S:Scope </curr-scope> 
+          <types> L:Map => L[X <- T] </types>
+          requires getKLabel(S) =/=K #klabel(`blockScope`)
 
      rule <k> scope(Scope:Scope, K:K)
               => pushLocals ~> K ~> popLocals ~> setScope(OldScope)

--- a/semantics/language/translation/function-def.k
+++ b/semantics/language/translation/function-def.k
@@ -218,7 +218,7 @@ module C-FUNCTION-DEF
           [structural]
      rule dummyBind(ListItem(typedDeclaration(T:Type, X:CId)) Params:List)
           => addToEnv(X, nonStatic)
-          ~> giveType(X, T)
+          ~> giveParamType(X, T)
           ~> dummyBind(Params)
           requires notBool isVoidType(T)
           [structural]

--- a/semantics/language/translation/function-def.k
+++ b/semantics/language/translation/function-def.k
@@ -34,7 +34,7 @@ module C-FUNCTION-DEF
                     functionObject(X,
                          // The return and parameter types from the definition.
                          t(getModifiers(T), functionType(elideDeclParams(innerType(T)),
-                              elideList(getParams(emptyToVoid(T))))),
+                              elideList(getParams(emptyToVoid(T))))), .List,
                          Goto(funLabel(X)))
                )))
           )
@@ -62,7 +62,7 @@ module C-FUNCTION-DEF
           ...</k>
           <env>... X |-> Base:SymBase ...</env>
           <functions>...
-               Base |-> functionObject(_, DefT:Type, _)
+               Base |-> functionObject(_, DefT:Type, _, _)
           ...</functions>
           [structural]
 

--- a/semantics/language/translation/function-def.k
+++ b/semantics/language/translation/function-def.k
@@ -64,6 +64,7 @@ module C-FUNCTION-DEF
           <functions>...
                Base |-> functionObject(_, DefT:Type, _, _)
           ...</functions>
+          <curr-function> _ => Base </curr-function>
           [structural]
 
      syntax KItem ::= checkFunDefType(CId, Type)

--- a/semantics/language/translation/init.k
+++ b/semantics/language/translation/init.k
@@ -109,7 +109,7 @@ module C-TRANSLATION-INIT
                typedDeclaration(T, B),
                initializer(Computation(initFunction(
                     &(B), B,
-                    functionObject(B, T, handleBuiltin)
+                    functionObject(B, T, .List, handleBuiltin)
                )))) ...</k>
           <external-types>... B |-> _ ...</external-types>
           <external-uses>... SetItem(B) ...</external-uses>

--- a/x86-gcc-limited-libc/semantics/settings.k
+++ b/x86-gcc-limited-libc/semantics/settings.k
@@ -51,5 +51,7 @@ module C-SETTINGS
      rule isErrorRecovery => false
      rule hasLint => false
 
+     rule cfg:stackSize(_, _) => 0
+
 endmodule
 


### PR DESCRIPTION
Basically handles two things: computation of the size of the stack at each point in the execution of the program, and some fixes for large writes to make them not be n^2 due to use of cons list internally for the List sort.

@chathhorn please review. Should be merged together with the second PR