### PR TITLE
use map for configuration

### DIFF
--- a/semantics/language/execution/configuration.k
+++ b/semantics/language/execution/configuration.k
@@ -25,7 +25,7 @@ module C-CONFIGURATION
      <linkings> .Map </linkings>
 
      <translation-units>
-          <tu multiplicity="*" type="Set">
+          <tu multiplicity="*" type="Map">
                <tu-id> "" </tu-id>
                <genv color="lightgray"> .Map </genv>
                <gtypes color="lightgray"> .Map </gtypes>

--- a/semantics/language/translation/configuration.k
+++ b/semantics/language/translation/configuration.k
@@ -29,7 +29,7 @@ module C-CONFIGURATION
      <linkings> .Map </linkings>
 
      <translation-units>
-          <tu multiplicity="*" type="Set">
+          <tu multiplicity="*" type="Map">
                <tu-id> "" </tu-id>
                <genv color="lightgray"> .Map </genv>
                <gtypes color="lightgray"> .Map </gtypes>


### PR DESCRIPTION
@chathhorn please review

Don't merge this yet, since it is dependent on code fixes in other pull requests. At a high level, we are making the tu cell be a map whose key is the first child (ie tu-id). This makes looking up info about a particular tu happen in log time instead of linear time.