### PR TITLE
name not found ==> ill-formed

### DIFF
--- a/semantics/cpp14/language/translation/overloading.k
+++ b/semantics/cpp14/language/translation/overloading.k
@@ -22,6 +22,7 @@ module CPP-OVERLOADING
      imports CPP-OVERLOADING-SYNTAX
      imports C-CONFIGURATION
      imports INT
+     imports STRING
      imports K-EQUAL
      imports CPP-DYNAMIC-SYNTAX
      imports CPP-ABSTRACT-SYNTAX
@@ -218,9 +219,9 @@ module CPP-OVERLOADING
           <references>... loc(Base, 0) |-> _ ...</references>
 
      rule resolveUniqueDecl(V:KResult, _) => V
-          requires notBool isCandidateSet(V)
+          requires notBool isCandidateSet(V) andBool notBool isNotFoundNameRef(V)
 
-     rule resolveUniqueDecl(notFound(_) => ILL("", "name not found"), _)
+     rule (.K => ILL("TOL1", "No declaration found for name '" +String idToString(X) +String "'.")) ~> resolveUniqueDecl(notFound(X::CId), _)
 
      rule wrapInThis(T:CPPType) => T
      rule catof(impliedObjArg(_) => prvalue)

--- a/semantics/cpp14/language/translation/overloading.k
+++ b/semantics/cpp14/language/translation/overloading.k
@@ -37,6 +37,7 @@ module CPP-OVERLOADING
      imports CPP-VALUE-CATEGORY-SYNTAX
      imports CPP-CLASS-SYNTAX
      imports CPP-DECL-CLASS-SYNTAX
+     imports ERROR-SYNTAX
 
      rule cSetUnion(notFound(_), E::Expr) => E
      rule cSetUnion(E::Expr, notFound(_)) => E
@@ -218,6 +219,8 @@ module CPP-OVERLOADING
 
      rule resolveUniqueDecl(V:KResult, _) => V
           requires notBool isCandidateSet(V)
+
+     rule resolveUniqueDecl(notFound(_) => ILL("", "name not found"), _)
 
      rule wrapInThis(T:CPPType) => T
      rule catof(impliedObjArg(_) => prvalue)


### PR DESCRIPTION
When name is not found during translation phase, `notFound(X)` term does not always make compilation fail, which is probably wrong. I am not sure exactly what message to pass to term ILL(_, _). Note that the following rule does not really help:

`rule resolveUniqueDecl(notFound(_), _) => ILL("", "name not found")`

