### PR TITLE
Value category for sizeof()

### DIFF
--- a/semantics/cpp14/language/translation/value-category.k
+++ b/semantics/cpp14/language/translation/value-category.k
@@ -81,6 +81,8 @@ module CPP-VALUE-CATEGORY
      rule catof(AlignofType(_) => prvalue)
      rule catof(NewExpr(_, _, _, _) => prvalue)
      rule catof(DeleteExpr(_, _, _) => prvalue)
+     rule catof(SizeofType(_) => prvalue)
+     rule catof(SizeofExpr(_) => prvalue)
 
      context catof(ParenthesizedCast(HOLE:AType, _))
      rule catof(ParenthesizedCast(T:CPPType, _) => unnamedCat(T))

--- a/tests/unit-pass/sizeof-is-prval.C
+++ b/tests/unit-pass/sizeof-is-prval.C
@@ -1,6 +1,5 @@
 // Tests that sizeof(_) can be used in initialization
 // (and thus it has a value category).
-// { dg-do run}
 int main()
 {
 	int x = sizeof(int);

--- a/tests/unit-pass/sizeof-is-prval.C
+++ b/tests/unit-pass/sizeof-is-prval.C
@@ -1,0 +1,8 @@
+// Tests that sizeof(_) can be used in initialization
+// (and thus it has a value category).
+// { dg-do run}
+int main()
+{
+	int x = sizeof(int);
+	int y = sizeof(5);
+}


### PR DESCRIPTION
Value category for sizeof() expression was missing, so it was not possible to compile code like the one in the test.