### PR TITLE
Result type of relational operators should be bool. fix #267

### DIFF
--- a/semantics/cpp14/language/translation/expr/relational.k
+++ b/semantics/cpp14/language/translation/expr/relational.k
@@ -6,29 +6,29 @@ module CPP-TRANSLATION-EXPR-RELATIONAL
      imports CPP-TYPING-SYNTAX
 
      rule R1:PRVal == R2:PRVal
-          => pre(stripHold(R1) == stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_==__CPP-SYNTAX`)), type(R1))
+          => pre(stripHold(R1) == stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_==__CPP-SYNTAX`)), type(bool))
           requires isPromoted(type(R1)) andBool type(R1) ==Type type(R2)
                andBool (isTExpr(R1) orBool isTExpr(R2))
 
      rule R1:PRVal != R2:PRVal
-          => pre(stripHold(R1) != stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_!=__CPP-SYNTAX`)), type(R1))
+          => pre(stripHold(R1) != stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_!=__CPP-SYNTAX`)), type(bool))
           requires isPromoted(type(R1)) andBool type(R1) ==Type type(R2)
                andBool (isTExpr(R1) orBool isTExpr(R2))
 
      rule R1:PRVal < R2:PRVal
-          => pre(stripHold(R1) < stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_<__CPP-SYNTAX`)), type(R1))
+          => pre(stripHold(R1) < stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_<__CPP-SYNTAX`)), type(bool))
           requires isPromoted(type(R1)) andBool type(R1) ==Type type(R2)
                andBool (isTExpr(R1) orBool isTExpr(R2))
      rule R1:PRVal > R2:PRVal
-          => pre(stripHold(R1) > stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_>__CPP-SYNTAX`)), type(R1))
+          => pre(stripHold(R1) > stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_>__CPP-SYNTAX`)), type(bool))
           requires isPromoted(type(R1)) andBool type(R1) ==Type type(R2)
                andBool (isTExpr(R1) orBool isTExpr(R2))
      rule R1:PRVal <= R2:PRVal
-          => pre(stripHold(R1) <= stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_<=__CPP-SYNTAX`)), type(R1))
+          => pre(stripHold(R1) <= stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_<=__CPP-SYNTAX`)), type(bool))
           requires isPromoted(type(R1)) andBool type(R1) ==Type type(R2)
                andBool (isTExpr(R1) orBool isTExpr(R2))
      rule R1:PRVal >= R2:PRVal
-          => pre(stripHold(R1) >= stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_>=__CPP-SYNTAX`)), type(R1))
+          => pre(stripHold(R1) >= stripHold(R2), combine(trace(R1), trace(R2), #klabel(`_>=__CPP-SYNTAX`)), type(bool))
           requires isPromoted(type(R1)) andBool type(R1) ==Type type(R2)
                andBool (isTExpr(R1) orBool isTExpr(R2))
 

--- a/tests/unit-pass/resulting-type-of-relational-operators.C
+++ b/tests/unit-pass/resulting-type-of-relational-operators.C
@@ -1,0 +1,12 @@
+/*
+ * Resulting type of relational operations should be bool
+ * and thus should be comparable to bool.
+ * This is essentially test for issue https://github.com/kframework/c-semantics/issues/267.
+ */
+
+int main()
+{
+	int x = 1;
+	if (true == (x == 2))
+		;
+}


### PR DESCRIPTION
See https://github.com/kframework/c-semantics/issues/267