### PR TITLE
C++ Enums + enumerators

### DIFF
--- a/cpp-parser/ClangKast.cc
+++ b/cpp-parser/ClangKast.cc
@@ -129,6 +129,9 @@ public:
   }
 
   bool TraverseStmt(Stmt *S) {
+    if (!S)
+      return RecursiveASTVisitor::TraverseStmt(S);
+
     if (Expr *E = dyn_cast<Expr>(S)) {
       AddKApplyNode("ExprLoc", 2);
       AddCabsLoc(E->getExprLoc());
@@ -988,19 +991,23 @@ bool TraverseDecl(Decl *D) {
   }
 
   bool TraverseEnumDecl(EnumDecl *D) {
-    if (D->isCompleteDefinition()) {
-      AddKApplyNode("EnumDef", 3);
-    } else {
-      AddKApplyNode("TypeDecl", 1);
-      AddKApplyNode("ElaboratedTypeSpecifier", 3);
-      VisitTagKind(D->getTagKind());
+    if (!D->isCompleteDefinition()) {
+      AddKApplyNode("OpaqueEnumDeclaration", 3);
+      TRY_TO(TraverseDeclarationName(D->getDeclName()));
+      VisitBool(D->isScoped());
+      TraverseType(D->getIntegerType());
+      return true;
     }
+
+    AddKApplyNode("EnumDef", 6);
     TRY_TO(TraverseDeclarationName(D->getDeclName()));
     TRY_TO(TraverseNestedNameSpecifierLoc(D->getQualifierLoc()));
-    if (D->isCompleteDefinition()) {
-      AddDeclContextNode(D);
-      TraverseDeclContextNode(D);
-    }
+    VisitBool(D->isScoped());
+    VisitBool(D->isFixed());
+    TraverseType(D->getIntegerType());
+
+    AddDeclContextNode(D);
+    TraverseDeclContextNode(D);
     return true;
   }
 

--- a/semantics/common/configuration.k
+++ b/semantics/common/configuration.k
@@ -100,6 +100,16 @@ module COMMON-CONFIGURATION
                          <access-specifier> .K </access-specifier>
                     </class>
                </classes>
+
+               <cpp-enums>
+                    <cppenum multiplicity="*" type="Map">
+                         <enum-id> .K </enum-id>
+                         <enum-type> .K </enum-type>
+                         <scoped> false </scoped>
+                         <enumerators> .List </enumerators>
+                    </cppenum>
+               </cpp-enums>
+
           </tu>
      </translation-units>
    </global>

--- a/semantics/common/configuration.k
+++ b/semantics/common/configuration.k
@@ -106,7 +106,10 @@ module COMMON-CONFIGURATION
                          <enum-id> .K </enum-id>
                          <enum-type> .K </enum-type>
                          <scoped> false </scoped>
-                         <enumerators> .List </enumerators>
+                         <enumerators> .Map </enumerators>
+                         <enum-complete> false </enum-complete>
+                         <enum-min> 0 </enum-min>
+                         <enum-max> 0 </enum-max>
                     </cppenum>
                </cpp-enums>
 

--- a/semantics/common/configuration.k
+++ b/semantics/common/configuration.k
@@ -77,6 +77,8 @@ module COMMON-CONFIGURATION
                          <ntypes> .Map </ntypes>
                          // CId |-> Namespace
                          <nested-namespaces> .Map </nested-namespaces>
+                         // CId |-> EnumId
+                         <unscoped-enumerators> .Map </unscoped-enumerators>
                          <is-inline> false </is-inline>
                          <using-namespaces> .Set </using-namespaces>
                          <inline-namespaces> .Set </inline-namespaces>

--- a/semantics/cpp14/language/common/alignment.k
+++ b/semantics/cpp14/language/common/alignment.k
@@ -54,6 +54,7 @@ module CPP-ALIGNMENT
      rule byteAlignofType(double) => cfg:alignofDouble
      rule byteAlignofType(long-double) => cfg:alignofLongDouble
      rule byteAlignofType(T:CPPSimpleWideCharType) => byteAlignofType(underlyingType(T))
+     rule byteAlignofType(T:CPPSimpleEnumType) => byteAlignofType(underlyingType(T))
      rule byteAlignofType(functionType(...)) => 0
      rule byteAlignofType(no-type) => cfg:alignofMalloc
 

--- a/semantics/cpp14/language/common/bitsize.k
+++ b/semantics/cpp14/language/common/bitsize.k
@@ -20,6 +20,7 @@ module CPP-BITSIZE
           => N +Int ((A *Int cfg:bitsPerByte) -Int (N %Int (A *Int cfg:bitsPerByte))) [owise]
 
      syntax Int ::= byteSizeofType(CPPSimpleType) [klabel(byteSizeofSimpleTypeCpp), function]
+     rule byteSizeofType(T:CPPEnumType) => byteSizeofType(underlyingType(T))
      rule byteSizeofType(T:CPPClassType) => byteSizeofClass(getClassInfo(T))
      rule byteSizeofType(t(_, _, T::CPPSimpleType)) => byteSizeofType(T) [owise]
 

--- a/semantics/cpp14/language/common/conversion.k
+++ b/semantics/cpp14/language/common/conversion.k
@@ -86,9 +86,9 @@ module CPP-CONVERSION
           ~> convertTypeHold(T, prv(C, Tr, T'))
           requires isCPPSignedType(underlyingType(T)) andBool notBool inRange(C, T)
      rule convertType(T::CPPType, prv(C::CPPValue, Tr::Trace, T':CPPIntegerType)) => arithInterpret(T, C, Tr)
-          requires isCPPUnsignedType(underlyingType(T)) andBool inRange(C, T)
+          requires notBool isCPPEnumType(T) andBool isCPPUnsignedType(underlyingType(T)) andBool inRange(C, T)
      rule convertType(T::CPPType, prv(N:Int, Tr::Trace, T':CPPIntegerType)) => prv(N modInt (max(T) +Int 1), Tr, T)
-          requires isCPPUnsignedType(underlyingType(T)) andBool notBool inRange(N, T)
+          requires notBool isCPPEnumType(T) andBool isCPPUnsignedType(underlyingType(T)) andBool notBool inRange(N, T)
      rule convertType(T:CPPIntegerType, prv(C::CPPValue, Tr::Trace, T':CPPBoolType)) => prv(C, Tr, T)
      rule convertType(T:CPPBoolType, prv(0, Tr::Trace, T':CPPIntegerType)) => prv(0, Tr, T)
      rule convertType(T:CPPBoolType, prv(I:Int, Tr::Trace, T':CPPIntegerType)) => prv(1, Tr, T)
@@ -230,7 +230,25 @@ module CPP-CONVERSION
                                                 type(underlyingType(T)) 
                                                 #fi #fi #fi #fi #fi #fi
           requires T ==K char16_t orBool T ==K char32_t orBool T ==K wchar_t
-     // TODO(dwightguth): 4.5:3-5
+
+     // 4.5:3
+     // TODO(h0nzZik) (1) store the type in configuration for performance reasons,
+     //               (2) what if we have an extended integer type other then the underlying type?
+     rule promote(t(_, _, unscopedEnum(_, _, false) #as T::CPPSimpleType)) =>
+               #if broaderTypeThan(type(int), type(T)) #then type(int) #else
+               #if broaderTypeThan(type(unsigned), type(T)) #then type(unsigned) #else
+               #if broaderTypeThan(type(long), type(T)) #then type(long) #else
+               #if broaderTypeThan(type(unsigned-long), type(T)) #then type(unsigned-long) #else
+               #if broaderTypeThan(type(long-long), type(T)) #then type(long-long) #else
+               #if broaderTypeThan(type(unsigned-long-long), type(T)) #then type(unsigned-long-long) #else
+               type(underlyingType(T))
+               #fi #fi #fi #fi #fi #fi
+
+     // 4.5:4
+     rule promote(t(_, _, unscopedEnum(_, UT::CPPIntegerType, true))) => promote(UT)
+
+     // TODO(dwightguth): 4.5:5
+
      // 4.5:6
      rule promote(t(_, _, bool)) => type(int)
      rule promote(T::CPPType) => T

--- a/semantics/cpp14/language/common/conversion.k
+++ b/semantics/cpp14/language/common/conversion.k
@@ -241,7 +241,7 @@ module CPP-CONVERSION
                #if broaderTypeThan(type(unsigned-long), type(T)) #then type(unsigned-long) #else
                #if broaderTypeThan(type(long-long), type(T)) #then type(long-long) #else
                #if broaderTypeThan(type(unsigned-long-long), type(T)) #then type(unsigned-long-long) #else
-               type(underlyingType(T))
+               type(underlyingType(T)) // Not reachable without extended integer types
                #fi #fi #fi #fi #fi #fi
 
      // 4.5:4

--- a/semantics/cpp14/language/common/dynamic.k
+++ b/semantics/cpp14/language/common/dynamic.k
@@ -163,6 +163,7 @@ module CPP-DYNAMIC-SYNTAX
      rule inClassScope(_:NamespaceScope) => false
      rule inClassScope(_:ClassScope) => true
      rule inClassScope(blockScope(QX::QualId, _, _)) => isClassQualId(QX)
+     rule inClassScope(enumScope(enumId(_))) => false
 
      syntax Bool ::= isClassQualId(QualId) [function]
      rule isClassQualId(C:Class :: _::CId) => true

--- a/semantics/cpp14/language/common/dynamic.k
+++ b/semantics/cpp14/language/common/dynamic.k
@@ -151,7 +151,8 @@ module CPP-DYNAMIC-SYNTAX
      syntax BlockScope ::= blockScope(QualId, SymBase, Int) [klabel(blockScopeCpp)]
      syntax TemplateParameterScope ::= "templateParameterScope"
      syntax FunctionPrototypeScope ::= "prototypeScope"
-     syntax Scope ::= NamespaceScope | ClassScope | BlockScope | TemplateParameterScope | FunctionPrototypeScope
+     syntax EnumScope ::= enumScope(Namespace, CId)
+     syntax Scope ::= NamespaceScope | ClassScope | BlockScope | TemplateParameterScope | FunctionPrototypeScope | EnumScope
 
      syntax Bool ::= inClassScope(Scope) [function]
      rule inClassScope(_:NamespaceScope) => false

--- a/semantics/cpp14/language/common/dynamic.k
+++ b/semantics/cpp14/language/common/dynamic.k
@@ -34,6 +34,7 @@ module CPP-DYNAMIC-SORTS
      syntax TemplateArg
      syntax CPPValue
      syntax ValueCategory
+     syntax EnumId
 endmodule
 
 module CPP-REVAL-SYNTAX
@@ -151,7 +152,7 @@ module CPP-DYNAMIC-SYNTAX
      syntax BlockScope ::= blockScope(QualId, SymBase, Int) [klabel(blockScopeCpp)]
      syntax TemplateParameterScope ::= "templateParameterScope"
      syntax FunctionPrototypeScope ::= "prototypeScope"
-     syntax EnumScope ::= enumScope(Namespace, CId)
+     syntax EnumScope ::= enumScope(EnumId)
      syntax Scope ::= NamespaceScope | ClassScope | BlockScope | TemplateParameterScope | FunctionPrototypeScope | EnumScope
 
      syntax Bool ::= inClassScope(Scope) [function]

--- a/semantics/cpp14/language/common/dynamic.k
+++ b/semantics/cpp14/language/common/dynamic.k
@@ -13,7 +13,8 @@ module CPP-DYNAMIC-SORTS
      syntax RExpr ::= XExpr | PRExpr
      syntax TExpr ::= GLExpr | RExpr
      syntax Expr ::= TExpr
-     syntax NNSVal ::= Namespace | Class | ClassTemplate
+     syntax Enum
+     syntax NNSVal ::= Namespace | Class | ClassTemplate | Enum
      syntax NNS ::= NNSVal | NNSSpecifier
      syntax Namespace
      syntax Class
@@ -34,7 +35,7 @@ module CPP-DYNAMIC-SORTS
      syntax TemplateArg
      syntax CPPValue
      syntax ValueCategory
-     syntax EnumId
+     syntax EnumId ::= enumId(Enum)
 endmodule
 
 module CPP-REVAL-SYNTAX
@@ -124,6 +125,9 @@ module CPP-DYNAMIC-SYNTAX
      syntax ClassTemplateSpecifier ::= Class(Tag, CId, TemplateParams) [klabel(classSpecifier)]
                                      | ClassSpecifier //not technically a class template, but this type exists primarily to support CPPClassTypeExpr, so it's needed
 
+     syntax Enum ::= ClassQualifier "::" EnumSpecifier
+     syntax EnumSpecifier ::= Enum(CId) [klabel(enumSpecifier)]
+
      syntax MaybeNNS ::= NNS | "noNNS"
      syntax MaybeNNS ::= getOuterClass(Class) [function]
      rule getOuterClass(C:Class :: _::ClassSpecifier) => C
@@ -159,6 +163,7 @@ module CPP-DYNAMIC-SYNTAX
      rule inClassScope(_:NamespaceScope) => false
      rule inClassScope(_:ClassScope) => true
      rule inClassScope(blockScope(QX::QualId, _, _)) => isClassQualId(QX)
+     rule inClassScope(enumScope(enumId(CQ::ClassQualifier :: _))) => isClass(CQ)
 
      syntax Bool ::= isClassQualId(QualId) [function]
      rule isClassQualId(C:Class :: _::CId) => true

--- a/semantics/cpp14/language/common/dynamic.k
+++ b/semantics/cpp14/language/common/dynamic.k
@@ -163,7 +163,6 @@ module CPP-DYNAMIC-SYNTAX
      rule inClassScope(_:NamespaceScope) => false
      rule inClassScope(_:ClassScope) => true
      rule inClassScope(blockScope(QX::QualId, _, _)) => isClassQualId(QX)
-     rule inClassScope(enumScope(enumId(CQ::ClassQualifier :: _))) => isClass(CQ)
 
      syntax Bool ::= isClassQualId(QualId) [function]
      rule isClassQualId(C:Class :: _::CId) => true

--- a/semantics/cpp14/language/common/error.k
+++ b/semantics/cpp14/language/common/error.k
@@ -5,6 +5,7 @@ module CPP-ERROR-SYNTAX
                     | IMPL(String, String) [klabel(IMPLCpp)]
                     | UNDEF(String, String) [klabel(UNDEFCpp)]
                     | DRAFTING(String, String) [klabel(DRAFTINGCpp)]
+                    | UNSPEC(String, String) [klabel(UNSPECCpp)]
 
 endmodule
 
@@ -20,6 +21,8 @@ module CPP-ERROR
           => EXIT(ErrorMsg(Impl(CPPLinkage), Title, Msg))
      rule UNDEF(Title:String, Msg:String)
           => EXIT(ErrorMsg(Undef(CPPLinkage), Title, Msg))
+     rule UNSPEC(Title:String, Msg:String)
+          => EXIT(ErrorMsg(Unspec(CPPLinkage), Title, Msg))
      rule DRAFTING(Title:String, Msg:String)
           => EXIT(ErrorMsg(Drafting(CPPLinkage), Title, Msg))
 

--- a/semantics/cpp14/language/common/memory/reading.k
+++ b/semantics/cpp14/language/common/memory/reading.k
@@ -47,4 +47,8 @@ module CPP-MEMORY-READING
      rule interpret(prv(0, Tr::Trace, T:CPPNullPtrTType)) => prv(nullptrVal, Tr, T)
      rule interpret(prv(0, Tr::Trace, T:CPPPointerType)) => prv(NullPointer, Tr, T)
 
+     syntax PRVal ::= interpretEnum(PRVal, CPPEnumType)
+     rule interpret(prv(I:Int, Tr::Trace, T:CPPEnumType)) => interpretEnum(interpret(prv(I, Tr, underlyingType(T))), T)
+     rule interpretEnum(prv(I:Int, Tr::Trace, T:CPPIntegerType), E:CPPEnumType) => prv(I, Tr, E)
+
 endmodule

--- a/semantics/cpp14/language/common/memory/reading.k
+++ b/semantics/cpp14/language/common/memory/reading.k
@@ -47,8 +47,6 @@ module CPP-MEMORY-READING
      rule interpret(prv(0, Tr::Trace, T:CPPNullPtrTType)) => prv(nullptrVal, Tr, T)
      rule interpret(prv(0, Tr::Trace, T:CPPPointerType)) => prv(NullPointer, Tr, T)
 
-     syntax PRVal ::= interpretEnum(PRVal, CPPEnumType)
-     rule interpret(prv(I:Int, Tr::Trace, T:CPPEnumType)) => interpretEnum(interpret(prv(I, Tr, underlyingType(T))), T)
-     rule interpretEnum(prv(I:Int, Tr::Trace, T:CPPIntegerType), E:CPPEnumType) => prv(I, Tr, E)
+     rule interpret(prv(I:Int, Tr::Trace, T:CPPEnumType)) => #fun(prv(I::Int, Tr::Trace, (T => T)))(interpret(prv(I, Tr, underlyingType(T))))
 
 endmodule

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -111,7 +111,7 @@ module CPP-TYPING-SYNTAX
      syntax CPPSimpleArrayTypeExpr ::= dynamicArrayType(CPPType, Expr)
 
      syntax CPPSimpleScopedEnumType ::= scopedEnum(id: EnumId, underlyingType: CPPIntegerType)
-     syntax CPPSimpleUnscopedEnumType ::= unscopedEnum(id: EnumId, underlyingType: CPPIntegerType)
+     syntax CPPSimpleUnscopedEnumType ::= unscopedEnum(id: EnumId, underlyingType: CPPIntegerType, utFixed: Bool)
      syntax CPPSimpleEnumType ::= CPPSimpleScopedEnumType | CPPSimpleUnscopedEnumType
      syntax CPPSimpleCompoundType ::= CPPSimpleEnumType
 
@@ -426,7 +426,7 @@ module CPP-TYPING
 
      rule t(Q::Quals, _, classType(N1::Namespace :: Class(T1::Tag, X1::CId, Ts1::TemplateArgs))) ==Type t(Q::Quals, _, classType(N2::Namespace :: Class(T2::Tag, X2::CId, Ts2::TemplateArgs))) => N1 ==K N2 andBool T1 ==K T2 andBool X1 ==K X2 andBool Ts1 ==Types Ts2
      rule t(Q::Quals, _, scopedEnum(X::EnumId, _)) ==Type t(Q, _, scopedEnum(X::EnumId, _)) => true
-     rule t(Q::Quals, _, unscopedEnum(X::EnumId, _)) ==Type t(Q, _, unscopedEnum(X::EnumId, _)) => true
+     rule t(Q::Quals, _, unscopedEnum(X::EnumId, _, _)) ==Type t(Q, _, unscopedEnum(X::EnumId, _, _)) => true
 
      syntax Bool ::= TemplateArgs "==Types" TemplateArgs [function]
      rule T1::CPPType, Ts1::TemplateArgs ==Types T2::CPPType, Ts2::TemplateArgs => T1 ==Type T2 andBool Ts1 ==Types Ts2
@@ -440,7 +440,7 @@ module CPP-TYPING
      rule underlyingType(t(Q::Quals, Mods::Set, T::CPPSimpleType))
           => t(Q, Mods, underlyingType(T))
      rule underlyingType(scopedEnum(_, T::CPPIntegerType)) => simpleType(T)
-     rule underlyingType(unscopedEnum(_, T::CPPIntegerType)) => simpleType(T)
+     rule underlyingType(unscopedEnum(_, T::CPPIntegerType, _)) => simpleType(T)
 
 
      rule inRange(I:Int, T::CPPIntegerType)
@@ -475,6 +475,12 @@ module CPP-TYPING
 
      rule min(T:CPPWideCharType) => min(underlyingType(T))
      rule max(T:CPPWideCharType) => max(underlyingType(T))
+
+     rule min(t(_, _, scopedEnum(_, UT::CPPIntegerType))) => min(UT)
+     rule max(t(_, _, scopedEnum(_, UT::CPPIntegerType))) => max(UT)
+
+     rule min(t(_, _, unscopedEnum(E::EnumId, _, _))) => #getEnumMin(#getEnumInfo(E, #configuration))
+     rule max(t(_, _, unscopedEnum(E::EnumId, _, _))) => #getEnumMax(#getEnumInfo(E, #configuration))
 
      rule precision(t(_, _, float)) => cfg:precisionofFloat
      rule precision(t(_, _, double)) => cfg:precisionofDouble
@@ -517,9 +523,14 @@ module CPP-TYPING
      rule setType(T::CPPType, prv(Loc::SymLoc, Tr::Trace, _)) => prv(Loc, Tr, T)
 
      rule getScoped(t(_, _, scopedEnum(_, _))) => true
-     rule getScoped(t(_, _, unscopedEnum(_, _))) => false
+     rule getScoped(t(_, _, unscopedEnum(_, _, _))) => false
      rule getEnumId(t(_, _, scopedEnum(X::EnumId, _))) => X
-     rule getEnumId(t(_, _, unscopedEnum(X::EnumId, _))) => X
+     rule getEnumId(t(_, _, unscopedEnum(X::EnumId, _, _))) => X
+
+     syntax Int ::= #getEnumMin(K) [function]
+                  | #getEnumMax(K) [function]
+     rule #getEnumMin(<cppenum>... <enum-min>Min::Int</enum-min>  ...</cppenum>) => Min
+     rule #getEnumMax(<cppenum>... <enum-max>Max::Int</enum-max>  ...</cppenum>) => Max
 
 endmodule
 

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -477,8 +477,11 @@ module CPP-TYPING
      rule min(t(_, _, scopedEnum(_, UT::CPPIntegerType))) => min(UT)
      rule max(t(_, _, scopedEnum(_, UT::CPPIntegerType))) => max(UT)
 
-     rule min(t(_, _, unscopedEnum(E::EnumId, _, _))) => #getEnumMin(#getEnumInfo(E, #configuration))
-     rule max(t(_, _, unscopedEnum(E::EnumId, _, _))) => #getEnumMax(#getEnumInfo(E, #configuration))
+     rule min(t(_, _, unscopedEnum(_, UT::CPPIntegerType, _))) => min(UT)
+     rule max(t(_, _, unscopedEnum(_, UT::CPPIntegerType, _))) => max(UT)
+
+     rule min(t(_, _, unscopedEnum(E::EnumId, _, false))) => #getEnumMin(#getEnumInfo(E, #configuration))
+     rule max(t(_, _, unscopedEnum(E::EnumId, _, false))) => #getEnumMax(#getEnumInfo(E, #configuration))
 
      rule precision(t(_, _, float)) => cfg:precisionofFloat
      rule precision(t(_, _, double)) => cfg:precisionofDouble

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -238,8 +238,6 @@ module CPP-TYPING-SYNTAX
                        | #getEnumInfo(EnumId, K) [function]
      syntax EnumInfo ::= CppenumCell | "#incomplete"
 
-     syntax EnumId ::= enumId(QualId)
-
      syntax Bool ::= CPPType "==Type" CPPType [function]
                    | CPPType "=/=Type" CPPType [function]
 

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -477,8 +477,8 @@ module CPP-TYPING
      rule min(t(_, _, scopedEnum(_, UT::CPPIntegerType))) => min(UT)
      rule max(t(_, _, scopedEnum(_, UT::CPPIntegerType))) => max(UT)
 
-     rule min(t(_, _, unscopedEnum(_, UT::CPPIntegerType, _))) => min(UT)
-     rule max(t(_, _, unscopedEnum(_, UT::CPPIntegerType, _))) => max(UT)
+     rule min(t(_, _, unscopedEnum(_, UT::CPPIntegerType, true))) => min(UT)
+     rule max(t(_, _, unscopedEnum(_, UT::CPPIntegerType, true))) => max(UT)
 
      rule min(t(_, _, unscopedEnum(E::EnumId, _, false))) => #getEnumMin(#getEnumInfo(E, #configuration))
      rule max(t(_, _, unscopedEnum(E::EnumId, _, false))) => #getEnumMax(#getEnumInfo(E, #configuration))

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -110,6 +110,11 @@ module CPP-TYPING-SYNTAX
                                 | "decltype(auto)"
      syntax CPPSimpleArrayTypeExpr ::= dynamicArrayType(CPPType, Expr)
 
+     syntax CPPSimpleScopedEnumType ::= scopedEnum(id: EnumId, underlyingType: CPPIntegerType)
+     syntax CPPSimpleUnscopedEnumType ::= unscopedEnum(id: EnumId, underlyingType: CPPIntegerType)
+     syntax CPPSimpleEnumType ::= CPPSimpleScopedEnumType | CPPSimpleUnscopedEnumType
+     syntax CPPSimpleCompoundType ::= CPPSimpleEnumType
+
      syntax CPPFunctionType ::= t(q: Quals, m: Set, st: CPPSimpleFunctionType) [klabel(tcpp)]
      syntax CPPArithmeticType ::= CPPIntegerType | CPPFloatingType
      syntax CPPScalarType ::= CPPArithmeticType | CPPEnumType | CPPPointerType | CPPMemberPointerType | CPPNullPtrTType
@@ -133,15 +138,18 @@ module CPP-TYPING-SYNTAX
      syntax CPPClassType ::= t(q: Quals, m: Set, st: CPPSimpleClassType) [klabel(tcpp)]
      syntax CPPWideCharType ::= t(q: Quals, m: Set, st: CPPSimpleWideCharType) [klabel(tcpp)]
      syntax CPPBitfieldType
+
      syntax CPPEnumType ::= CPPScopedEnumType | CPPUnscopedEnumType
-     syntax CPPScopedEnumType
-     syntax CPPUnscopedEnumType
+     syntax CPPScopedEnumType ::= t(q: Quals, m: Set, st: CPPSimpleScopedEnumType) [klabel(tcpp)]
+     syntax CPPUnscopedEnumType ::= t(q: Quals, m: Set, st: CPPSimpleUnscopedEnumType) [klabel(tcpp)]
+
      syntax CPPType ::= CPPFunctionType
                       | CPPScalarType
                       | CPPRefType
                       | CPPArrayType 
                       | CPPClassType 
                       | CPPFundamentalType
+
 
      syntax CPPFunctionTypeExpr ::= CPPFunctionType | t(q: Quals, m: Set, st: CPPSimpleFunctionTypeExpr) [klabel(tcpp)]
      syntax CPPClassTypeExpr ::= CPPClassType | t(q: Quals, m: Set, st: CPPSimpleClassTypeExpr) [klabel(tcpp)]
@@ -226,6 +234,12 @@ module CPP-TYPING-SYNTAX
                    | isBaseClassOf(Class, Class) [function, klabel(isClassBaseClassOf)]
                    | hasVirtualMembers(CPPClassType) [function]
 
+     syntax EnumInfo ::= getEnumInfo(CPPEnumType) [function]
+                       | #getEnumInfo(EnumId, K) [function]
+     syntax EnumInfo ::= CppenumCell | "#incomplete"
+
+     syntax EnumId ::= enumId(QualId)
+
      syntax Bool ::= CPPType "==Type" CPPType [function]
                    | CPPType "=/=Type" CPPType [function]
 
@@ -237,6 +251,8 @@ module CPP-TYPING-SYNTAX
                    | isUnnamedXValue(CPPType) [function]
                    | isUnnamedPRValue(CPPType) [function]
 
+     syntax EnumId ::= getEnumId(CPPEnumType) [function]
+     syntax Bool ::= getScoped(CPPEnumType) [function]
 endmodule
 
 module CPP-TYPING
@@ -366,8 +382,14 @@ module CPP-TYPING
      rule #getClassInfo(t(_, _, classType(C::Class)), <generatedTop>... <class> <class-id> C </class-id> B::Bag </class> ...</generatedTop>) => <class> <class-id> C </class-id> B </class>
      rule #getClassInfo(_, _) => #incomplete [owise]
 
+     rule getEnumInfo(E::CPPEnumType) => #getEnumInfo(getEnumId(E), #configuration)
+
+     rule #getEnumInfo(X::EnumId, <generatedTop>... <cppenum> <enum-id> X </enum-id> B::Bag </cppenum> ...</generatedTop>) => <cppenum> <enum-id> X </enum-id> B </cppenum>
+     rule #getEnumInfo(_, _) => #incomplete [owise]
+
      rule isCompleteType(t(_, _, incompleteArrayType(_))) => false
-     rule isCompleteType(T:CPPEnumType) => false //TODO(dwightguth): true in certain cases
+     rule isCompleteType(T:CPPEnumType) => getEnumInfo(T) =/=K #incomplete //TODO(h0nzZik): false in 7.2, par 6
+
      rule isCompleteType(T:CPPClassType) => getClassInfo(T) =/=K #incomplete
      rule isCompleteType(T:CPPArrayType) => false
           requires notBool isCompleteType(innerType(T))
@@ -403,6 +425,9 @@ module CPP-TYPING
      rule noMethod ==Type methodInfo(... refQual: RQ::RefQualifier, cvQuals: Q::Quals) => RQ ==K RefNone() andBool Q ==K noQuals 
 
      rule t(Q::Quals, _, classType(N1::Namespace :: Class(T1::Tag, X1::CId, Ts1::TemplateArgs))) ==Type t(Q::Quals, _, classType(N2::Namespace :: Class(T2::Tag, X2::CId, Ts2::TemplateArgs))) => N1 ==K N2 andBool T1 ==K T2 andBool X1 ==K X2 andBool Ts1 ==Types Ts2
+     rule t(Q::Quals, _, scopedEnum(X::EnumId, _)) ==Type t(Q, _, scopedEnum(X::EnumId, _)) => true
+     rule t(Q::Quals, _, unscopedEnum(X::EnumId, _)) ==Type t(Q, _, unscopedEnum(X::EnumId, _)) => true
+
      syntax Bool ::= TemplateArgs "==Types" TemplateArgs [function]
      rule T1::CPPType, Ts1::TemplateArgs ==Types T2::CPPType, Ts2::TemplateArgs => T1 ==Type T2 andBool Ts1 ==Types Ts2
      rule .TemplateArgs ==Types .TemplateArgs => true
@@ -414,6 +439,9 @@ module CPP-TYPING
      rule underlyingType(T::CPPSimpleType) => T [owise]
      rule underlyingType(t(Q::Quals, Mods::Set, T::CPPSimpleType))
           => t(Q, Mods, underlyingType(T))
+     rule underlyingType(scopedEnum(_, T::CPPIntegerType)) => simpleType(T)
+     rule underlyingType(unscopedEnum(_, T::CPPIntegerType)) => simpleType(T)
+
 
      rule inRange(I:Int, T::CPPIntegerType)
           => I <=Int max(T) andBool I >=Int min(T)
@@ -487,6 +515,11 @@ module CPP-TYPING
 
      rule setType(T::CPPType, lv(Loc::SymLoc, Tr::Trace, _)) => lv(Loc, Tr, T)
      rule setType(T::CPPType, prv(Loc::SymLoc, Tr::Trace, _)) => prv(Loc, Tr, T)
+
+     rule getScoped(t(_, _, scopedEnum(_, _))) => true
+     rule getScoped(t(_, _, unscopedEnum(_, _))) => false
+     rule getEnumId(t(_, _, scopedEnum(X::EnumId, _))) => X
+     rule getEnumId(t(_, _, unscopedEnum(X::EnumId, _))) => X
 
 endmodule
 

--- a/semantics/cpp14/language/translation/decl/class.k
+++ b/semantics/cpp14/language/translation/decl/class.k
@@ -36,7 +36,7 @@ module CPP-DECL-CLASS
              requires notBool isClassNameElabSpecifier(HOLE) [result(CPPTypeExpr)]
      context TypeDecl(HOLE:CPPTypeExpr)
              requires notBool isDependentInScope(HOLE)
-                  andBool notBool isClassNameElabSpecifier(HOLE) [resullt(CPPType)]
+                  andBool notBool isClassNameElabSpecifier(HOLE) [result(CPPType)]
 
      syntax Bool ::= isClassNameElabSpecifier(K) [function]
      rule isClassNameElabSpecifier(ElaboratedTypeSpecifier(_:ClassKey, _, NoNNS())) => true

--- a/semantics/cpp14/language/translation/decl/enum.k
+++ b/semantics/cpp14/language/translation/decl/enum.k
@@ -80,23 +80,52 @@ module CPP-DECL-ENUM
                <enum-complete> false </enum-complete>
            ...</cppenum>)
 
-     syntax KItem ::= declareEnumerators(CPPEnumType, min: Int, max: Int, next: Int, nextType: CPPSimpleType, List, fixed: Bool, first: Bool)
+     syntax KItem ::= declareEnumerators(CPPEnumType, min: Int, max: Int, next: Int, prevType: CPPSimpleType, List, fixed: Bool, first: Bool)
 
-     rule declareEnumerators(_, _, _, Next::Int, NextType::CPPSimpleType, ListItem(Enumerator(_, NoExpression() => prv(Next, noTrace, type(NextType)))) _::List, _, _)
+     // First enumerator, fixed underlying type.
+     rule declareEnumerators(E::CPPEnumType, _, _, _, _, ListItem(Enumerator(_, NoExpression() => prv(0, noTrace, underlyingType(E)))) _::List, true, true)
+
+     // First enumerator, underlying type not fixed
+     rule (.K => UNSPEC("TDE2", "No initializer specified for the first enumerator")) ~> (
+          declareEnumerators(E::CPPEnumType, Min::Int, Max::Int, Next::Int, PrevType::CPPSimpleType, ListItem(Enumerator(X::CId, NoExpression())) L::List, false, true)
+          => recoverFromError(
+          declareEnumerators(E, Min, Max, Next, PrevType, ListItem(Enumerator(X, prv(0, noTrace, type(int)))) L, false, true)
+          ))
+
+     // Second or more enumerator, fixed underlying type
+     rule declareEnumerators(E::CPPEnumType, _, _, Next::Int, _,
+               ListItem(Enumerator(_, NoExpression() => prv(Next, noTrace, underlyingType(E)))) _::List, true, false)
+
+     // Second or more enumerator, underlying type not fixed, value fits.
+     rule declareEnumerators(_, _, _, Next::Int, PrevType::CPPSimpleType,
+               ListItem(Enumerator(_, NoExpression() => prv(Next, noTrace, type(PrevType)))) _::List, false, false)
+          requires inRange(Next, type(PrevType))
+
+     // Second or more enumerator, underlype type not fixed, value does not fit to previous type but fits to some.
+     rule (.K => UNSPEC("TDE3", "Value does not fit to type of preceding enumerator")) ~> (
+          declareEnumerators(E::CPPEnumType, Min::Int, Max::Int, Next::Int, PrevType::CPPSimpleType, ListItem(Enumerator(X::CId, NoExpression())) L::List, false, false)
+          => recoverFromError(
+          declareEnumerators(E, Min, Max, Next::Int, PrevType, ListItem(Enumerator(X, prv(Next, noTrace, type(firstSuitableType(Next, Next, allIntegralTypes))))) L, false, false)
+          ))
+          requires notBool inRange(Next, type(PrevType)) andBool firstSuitableType(Next, Next, allIntegralTypes) =/=K no-type
+
+     rule (.K => ILL("TDE4", "Incremented enumerator value is not representable in any integer type")) ~>
+          declareEnumerators(_, _, _, Next::Int, PrevType::CPPSimpleType, ListItem(Enumerator(_, NoExpression())) _::List, false, false)
+          requires notBool inRange(Next, type(PrevType)) andBool firstSuitableType(Next, Next, allIntegralTypes) ==K no-type
+
+     rule declareEnumerators(_, _, _, _, _, ListItem(Enumerator(_, prv(_, _, T:CPPEnumType => underlyingType(T)))) _::List, _, _)
      context declareEnumerators(_, _, _, _, _, ListItem(Enumerator(_, HOLE:Expr)) _::List, _, _)
 
      // Type of an enumerator inside the declaration is enum's underlying type
      // if it is fixed, and type of initializing expression otherwise,
      // Hence we need to store the type of underlying expression...
-     rule declareEnumerators(T::CPPEnumType, Min::Int, Max::Int, Next::Int, _, ListItem(Enumerator(X::CId, prv(V::Int, _, t(_, _, EType::CPPSimpleType)) #as Pr::PRVal)) L::List, Fixed::Bool, true)
+     rule declareEnumerators(T::CPPEnumType, Min::Int, Max::Int, Next::Int, _, ListItem(Enumerator(X::CId, prv(V::Int, _, t(_, _, EType::CPPSimpleType)) #as Pr::PRVal)) L::List, Fixed::Bool, First::Bool)
           => declareEnumerator(getEnumId(T), X, Pr, Fixed, underlyingType(T))
-          ~> declareEnumerators(T, V, V, V +Int 1, chooseEnumeratorType(EType, V +Int 1), L, Fixed, false)
+          ~> declareEnumerators(T, ite(First, V, minInt(Min, V)), ite(First, V, maxInt(Max, V)), V +Int 1, EType, L, Fixed, false)
 
-     rule declareEnumerators(T::CPPEnumType, Min::Int, Max::Int, Next::Int, _, ListItem(Enumerator(X::CId, prv(V::Int, _, t(_, _, EType::CPPSimpleType)) #as Pr::PRVal)) L::List, Fixed::Bool, false)
-          => declareEnumerator(getEnumId(T), X, Pr, Fixed, underlyingType(T))
-          ~> declareEnumerators(T, minInt(Min, V), maxInt(Max, V), V +Int 1, chooseEnumeratorType(EType, V +Int 1), L, Fixed, false)
-
-
+     syntax Int ::= ite(Bool, Int, Int) [function]
+     rule ite(true, X::Int, _) => X
+     rule ite(false, _, X::Int) => X
 
      // Enums with fixed underlying type are finished by now.
      rule declareEnumerators(T::CPPEnumType, _, _, _, _, .List, true, _) => .
@@ -113,8 +142,8 @@ module CPP-DECL-ENUM
      rule declareEnumerator(E::EnumId, X::CId, prv(V::CPPValue, Tr::Trace, _), true, UT::CPPIntegerType) => addEnumerator(E, X, prv(V, Tr, UT))
      requires inRange(V, UT)
 
-     rule (.K => ILL("TDE1", "Value of enumerator '" +String idToString(X) +String "' does not fit to underlying type.")) ~> declareEnumerator(_, X::CId, prv(V::CPPValue, _, _), true, UT::CPPIntegerType)
-     requires notBool inRange(V, UT)
+     rule (.K => ILL("TDE1", "Value of enumerator '" +String idToString(X) +String "' does not fit to fixed underlying type.")) ~> declareEnumerator(_, X::CId, prv(V::CPPValue, _, _), true, UT::CPPIntegerType)
+          requires notBool inRange(V, UT)
 
      syntax KItem ::= addEnumerator(enum: EnumId, id: CId, v: PRVal)
      rule <k> addEnumerator(E::EnumId, X::CId, V::PRVal) => addEnumeratorToEnv(E, X) ... </k>
@@ -141,9 +170,6 @@ module CPP-DECL-ENUM
           <ns-id> N </ns-id>
           <unscoped-enumerators> UE::Map (.Map => X |-> E ) </unscoped-enumerators>
 
-     syntax CPPSimpleType ::= chooseEnumeratorType(CPPSimpleType, Int) [function]
-     rule chooseEnumeratorType(T::CPPSimpleType, Val::Int) => #if inRange(Val, type(T)) #then T #else firstSuitableType(Val, Val, allIntegralTypes) #fi
-
      // For unscoped enums without fixed type,
      // compute their minimal and maximal value
      // as well as their underlying type
@@ -158,7 +184,6 @@ module CPP-DECL-ENUM
              ListItem(long-long)
              ListItem(unsigned-long-long)
 
-     //
      syntax List ::= "allIntegralTypes" [function]
      rule allIntegralTypes
           => ListItem(signed-char)
@@ -167,12 +192,11 @@ module CPP-DECL-ENUM
              ListItem(unsigned-short)
              integralTypesGreaterThanInt
 
-
-     
      syntax CPPSimpleType ::= firstSuitableType(Int, Int, List) [function]
      rule firstSuitableType(Min::Int, Max::Int, ListItem(T::CPPSimpleType) _) => T
           requires Min >=Int min(type(T)) andBool Max <=Int max(type(T))
-     rule firstSuitableType(_, _, .List) => int
+
+     rule firstSuitableType(_, _, .List) => no-type
      rule firstSuitableType(_, _, (ListItem(_) => .List) _) [owise]
 
 

--- a/semantics/cpp14/language/translation/decl/enum.k
+++ b/semantics/cpp14/language/translation/decl/enum.k
@@ -14,9 +14,11 @@ module CPP-DECL-ENUM
      imports CPP-ABSTRACT-SYNTAX
      imports CPP-DYNAMIC-SYNTAX
      imports CPP-ENV-SYNTAX
+     imports CPP-ERROR-SYNTAX
      imports CPP-SYNTAX
      imports CPP-BITSIZE-SYNTAX
      imports INT
+     imports STRING
 
      rule <k> EnumDef(X::CId, NoNNS(), Scoped::Bool, Fixed::Bool, UT::CPPIntegerType, Enumerators::List)
           => enumContext(X, declareEnumName(createEnumName(X, Sc), UT, Scoped, Fixed), Enumerators, Fixed, UT) ...</k>
@@ -107,8 +109,12 @@ module CPP-DECL-ENUM
      // Not fixed
      rule declareEnumerator(E::EnumId, X::CId, prv(_,_,_) #as Pr::PRVal, false, _) => addEnumerator(E, X, Pr)
 
-     // Fixed enumerator. TODO check that the value fits into the UT
+     // Fixed enumerator.
      rule declareEnumerator(E::EnumId, X::CId, prv(V::CPPValue, Tr::Trace, _), true, UT::CPPIntegerType) => addEnumerator(E, X, prv(V, Tr, UT))
+     requires inRange(V, UT)
+
+     rule (.K => ILL("TDE1", "Value of enumerator '" +String idToString(X) +String "' does not fit to underlying type.")) ~> declareEnumerator(_, X::CId, prv(V::CPPValue, _, _), true, UT::CPPIntegerType)
+     requires notBool inRange(V, UT)
 
      syntax KItem ::= addEnumerator(enum: EnumId, id: CId, v: PRVal)
      rule <k> addEnumerator(E::EnumId, X::CId, V::PRVal) => addEnumeratorToEnv(E, X) ... </k>

--- a/semantics/cpp14/language/translation/decl/enum.k
+++ b/semantics/cpp14/language/translation/decl/enum.k
@@ -1,0 +1,56 @@
+module CPP-DECL-ENUM-SYNTAX
+     imports BOOL-SYNTAX
+     imports LIST
+     imports COMMON-SORTS
+     imports CPP-SORTS
+     imports CPP-TYPING-SYNTAX
+endmodule
+
+module CPP-DECL-ENUM
+     imports CPP-DECL-ENUM-SYNTAX
+     imports C-CONFIGURATION
+     imports COMMON-SYNTAX
+     imports COMPAT-SYNTAX
+     imports CPP-ABSTRACT-SYNTAX
+     imports CPP-DYNAMIC-SYNTAX
+     imports CPP-ENV-SYNTAX
+     imports CPP-SYNTAX
+     imports CPP-BITSIZE-SYNTAX
+
+     syntax CPPEnumType ::= declareEnumName(ns: Namespace, id: CId, ut: CPPIntegerType, scoped: Bool) [function]
+     rule declareEnumName(N::Namespace, X::CId, UT::CPPIntegerType, false) => t(noQuals, .Set, unscopedEnum(enumId(N::Namespace :: X), UT))
+     rule declareEnumName(N::Namespace, X::CId, UT::CPPIntegerType, true)  => t(noQuals, .Set,   scopedEnum(enumId(N::Namespace :: X), UT))
+
+     syntax KItem ::= addToCurrentNamespace(CId, CPPEnumType)
+     rule <k> addToCurrentNamespace(X::CId, E::CPPEnumType) => . ... </k>
+          <curr-scope> namespaceScope(N::Namespace) </curr-scope>
+          <curr-tu> Tu::String </curr-tu>
+          <tu-id> Tu </tu-id>
+          <ns-id> N </ns-id>
+          <ntypes> NT::Map => NT[X, Enum() <- E] </ntypes>
+
+     // second param -underlying type
+     syntax KItem ::= newEnum(CPPEnumType)
+
+     rule <k> newEnum(E:CPPEnumType) => . ... </k>
+          <curr-tu> Tu::String </curr-tu>
+          <tu-id> Tu </tu-id>
+          (.Bag => <cppenum>...
+               <enum-id> getEnumId(E) </enum-id>
+               <enum-type> E </enum-type>
+               <scoped> getScoped(E) </scoped>
+           ...</cppenum>)
+
+     syntax KItem ::= enumContext(CId, CPPEnumType) [strict(2)]
+
+     // We do not support enumerators yet
+     rule <k> EnumDef(X::CId, NoNNS(), Scoped::Bool, Fixed::Bool, UT::CPPIntegerType, .List)
+          => enumContext(X, declareEnumName(N, X, UT, Scoped)) ...</k>
+          <curr-scope> namespaceScope(N::Namespace) </curr-scope>
+          <curr-tu> Tu::String </curr-tu>
+          <tu-id> Tu </tu-id>
+
+     rule enumContext(X::CId, E::CPPEnumType) => newEnum(E) ~> addToCurrentNamespace(X, E)
+
+endmodule
+

--- a/semantics/cpp14/language/translation/decl/enum.k
+++ b/semantics/cpp14/language/translation/decl/enum.k
@@ -119,13 +119,9 @@ module CPP-DECL-ENUM
      // Type of an enumerator inside the declaration is enum's underlying type
      // if it is fixed, and type of initializing expression otherwise,
      // Hence we need to store the type of underlying expression...
-     rule declareEnumerators(T::CPPEnumType, Min::Int, Max::Int, Next::Int, _, ListItem(Enumerator(X::CId, prv(V::Int, _, t(_, _, EType::CPPSimpleType)) #as Pr::PRVal)) L::List, Fixed::Bool, First::Bool)
+     rule declareEnumerators(T::CPPEnumType, Min::Int, Max::Int, Next::Int, _, ListItem(Enumerator(X::CId, prv(V::Int, _, t(_, _, EType::CPPSimpleType)) #as Pr::PRVal)) L::List, Fixed:Bool, First:Bool)
           => declareEnumerator(getEnumId(T), X, Pr, Fixed, underlyingType(T))
-          ~> declareEnumerators(T, ite(First, V, minInt(Min, V)), ite(First, V, maxInt(Max, V)), V +Int 1, EType, L, Fixed, false)
-
-     syntax Int ::= ite(Bool, Int, Int) [function]
-     rule ite(true, X::Int, _) => X
-     rule ite(false, _, X::Int) => X
+          ~> declareEnumerators(T, #if First #then V #else minInt(Min, V) #fi, #if First #then V #else maxInt(Max, V) #fi, V +Int 1, EType, L, Fixed, false)
 
      // Enums with fixed underlying type are finished by now.
      rule declareEnumerators(T::CPPEnumType, _, _, _, _, .List, true, _) => .

--- a/semantics/cpp14/language/translation/decl/enum.k
+++ b/semantics/cpp14/language/translation/decl/enum.k
@@ -86,7 +86,7 @@ module CPP-DECL-ENUM
      rule declareEnumerators(E::CPPEnumType, _, _, _, _, ListItem(Enumerator(_, NoExpression() => prv(0, noTrace, underlyingType(E)))) _::List, true, true)
 
      // First enumerator, underlying type not fixed
-     rule (.K => UNSPEC("TDE2", "No initializer specified for the first enumerator")) ~> (
+     rule (.K => UNSPEC("TDE2", "No initializer specified for the first enumerator, underlying type of enumerator is unspecified")) ~> (
           declareEnumerators(E::CPPEnumType, Min::Int, Max::Int, Next::Int, PrevType::CPPSimpleType, ListItem(Enumerator(X::CId, NoExpression())) L::List, false, true)
           => recoverFromError(
           declareEnumerators(E, Min, Max, Next, PrevType, ListItem(Enumerator(X, prv(0, noTrace, type(int)))) L, false, true)

--- a/semantics/cpp14/language/translation/decl/enum.k
+++ b/semantics/cpp14/language/translation/decl/enum.k
@@ -16,41 +16,197 @@ module CPP-DECL-ENUM
      imports CPP-ENV-SYNTAX
      imports CPP-SYNTAX
      imports CPP-BITSIZE-SYNTAX
+     imports INT
 
-     syntax CPPEnumType ::= declareEnumName(ns: Namespace, id: CId, ut: CPPIntegerType, scoped: Bool) [function]
-     rule declareEnumName(N::Namespace, X::CId, UT::CPPIntegerType, false) => t(noQuals, .Set, unscopedEnum(enumId(N::Namespace :: X), UT))
-     rule declareEnumName(N::Namespace, X::CId, UT::CPPIntegerType, true)  => t(noQuals, .Set,   scopedEnum(enumId(N::Namespace :: X), UT))
+     rule <k> EnumDef(X::CId, NoNNS(), Scoped::Bool, Fixed::Bool, UT::CPPIntegerType, Enumerators::List)
+          => enumContext(X, declareEnumName(createEnumName(X, Sc), UT, Scoped, Fixed), Enumerators, Fixed, UT) ...</k>
+          <curr-scope> Sc::Scope </curr-scope>
+          <curr-tu> Tu::String </curr-tu>
+          <tu-id> Tu </tu-id>
 
-     syntax KItem ::= addToCurrentNamespace(CId, CPPEnumType)
-     rule <k> addToCurrentNamespace(X::CId, E::CPPEnumType) => . ... </k>
-          <curr-scope> namespaceScope(N::Namespace) </curr-scope>
+     syntax Enum ::= createEnumName(CId, Scope) [function]
+     rule createEnumName(X::CId, namespaceScope(N::Namespace)) => N :: Enum(X)
+     rule createEnumName(X::CId, classScope(C::Class)) => C :: Enum(X)
+     rule createEnumName(X::CId, blockScope(_, _, _) #as B::BlockScope) => localQual(B) :: Enum(X)
+
+     syntax CPPEnumType ::= declareEnumName(Enum, ut: CPPIntegerType, scoped: Bool, fixed: Bool) [function]
+     rule declareEnumName(E::Enum, UT::CPPIntegerType, false, Fixed:Bool) => t(noQuals, .Set, unscopedEnum(enumId(E), UT, false))
+     rule declareEnumName(E::Enum, UT::CPPIntegerType, true, true)  => t(noQuals, .Set, scopedEnum(enumId(E), UT))
+
+     syntax Scope ::= getEnumScope(EnumId) [function]
+     rule getEnumScope(enumId(N:Namespace :: _)) => namespaceScope(N)
+
+     syntax KItem ::= addEnumToEnv(CId, CPPEnumType)
+     rule addEnumToEnv(X::CId, E::CPPEnumType) => #addEnumToEnv(X, getEnumScope(getEnumId(E)), E)
+
+     syntax KItem ::= #addEnumToEnv(CId, Scope, CPPEnumType)
+     rule <k> #addEnumToEnv(X::CId, namespaceScope(N::Namespace), E::CPPEnumType) => . ... </k>
           <curr-tu> Tu::String </curr-tu>
           <tu-id> Tu </tu-id>
           <ns-id> N </ns-id>
           <ntypes> NT::Map => NT[X, Enum() <- E] </ntypes>
 
-     // second param -underlying type
-     syntax KItem ::= newEnum(CPPEnumType)
+     syntax KItem ::= enumContext(CId, CPPEnumType, List, fixed: Bool, ut: CPPIntegerType) [strict(2)]
 
-     rule <k> newEnum(E:CPPEnumType) => . ... </k>
+     rule enumContext(X::CId, E::CPPEnumType, Enumerators:List, Fixed::Bool, UT::CPPIntegerType)
+          => newEnum(E, Fixed)
+          ~> addEnumToEnv(X, E)
+          ~> scope(enumScope(getEnumId(E)), declareEnumerators(E, 0, 0, 0, int, Enumerators, Fixed, true))
+
+     // second param -underlying type
+     syntax KItem ::= newEnum(CPPEnumType, fixed: Bool)
+
+     rule <k> newEnum(E:CPPEnumType, true) => . ... </k>
           <curr-tu> Tu::String </curr-tu>
           <tu-id> Tu </tu-id>
           (.Bag => <cppenum>...
                <enum-id> getEnumId(E) </enum-id>
                <enum-type> E </enum-type>
                <scoped> getScoped(E) </scoped>
+               <enum-complete> true </enum-complete>
+               <enum-min> min(underlyingType(E)) </enum-min>
+               <enum-max> max(underlyingType(E)) </enum-max>
            ...</cppenum>)
 
-     syntax KItem ::= enumContext(CId, CPPEnumType) [strict(2)]
-
-     // We do not support enumerators yet
-     rule <k> EnumDef(X::CId, NoNNS(), Scoped::Bool, Fixed::Bool, UT::CPPIntegerType, .List)
-          => enumContext(X, declareEnumName(N, X, UT, Scoped)) ...</k>
-          <curr-scope> namespaceScope(N::Namespace) </curr-scope>
+     rule <k> newEnum(E:CPPUnscopedEnumType, false) => . ... </k>
           <curr-tu> Tu::String </curr-tu>
           <tu-id> Tu </tu-id>
+          (.Bag => <cppenum>...
+               <enum-id> getEnumId(E) </enum-id>
+               <enum-type> E </enum-type>
+               <scoped> false </scoped>
+               <enum-complete> false </enum-complete>
+           ...</cppenum>)
 
-     rule enumContext(X::CId, E::CPPEnumType) => newEnum(E) ~> addToCurrentNamespace(X, E)
+     syntax KItem ::= declareEnumerators(CPPEnumType, min: Int, max: Int, next: Int, nextType: CPPSimpleType, List, fixed: Bool, first: Bool)
+
+     rule declareEnumerators(_, _, _, Next::Int, NextType::CPPSimpleType, ListItem(Enumerator(_, NoExpression() => prv(Next, noTrace, type(NextType)))) _::List, _, _)
+     context declareEnumerators(_, _, _, _, _, ListItem(Enumerator(_, HOLE:Expr)) _::List, _, _)
+
+     // Type of an enumerator inside the declaration is enum's underlying type
+     // if it is fixed, and type of initializing expression otherwise,
+     // Hence we need to store the type of underlying expression...
+     rule declareEnumerators(T::CPPEnumType, Min::Int, Max::Int, Next::Int, _, ListItem(Enumerator(X::CId, prv(V::Int, _, t(_, _, EType::CPPSimpleType)) #as Pr::PRVal)) L::List, Fixed::Bool, true)
+          => declareEnumerator(getEnumId(T), X, Pr, Fixed, underlyingType(T))
+          ~> declareEnumerators(T, V, V, V +Int 1, chooseEnumeratorType(EType, V +Int 1), L, Fixed, false)
+
+     rule declareEnumerators(T::CPPEnumType, Min::Int, Max::Int, Next::Int, _, ListItem(Enumerator(X::CId, prv(V::Int, _, t(_, _, EType::CPPSimpleType)) #as Pr::PRVal)) L::List, Fixed::Bool, false)
+          => declareEnumerator(getEnumId(T), X, Pr, Fixed, underlyingType(T))
+          ~> declareEnumerators(T, minInt(Min, V), maxInt(Max, V), V +Int 1, chooseEnumeratorType(EType, V +Int 1), L, Fixed, false)
+
+
+
+     // Enums with fixed underlying type are finished by now.
+     rule declareEnumerators(T::CPPEnumType, _, _, _, _, .List, true, _) => .
+
+     rule declareEnumerators(T::CPPUnscopedEnumType, Min::Int, Max::Int, _, _, .List, false, _) => calculateEnumValues(T, Min, Max)
+
+
+     syntax KItem ::= declareEnumerator(EnumId, CId, PRVal, fixed: Bool, ut: CPPType)
+
+     // Not fixed
+     rule declareEnumerator(E::EnumId, X::CId, prv(_,_,_) #as Pr::PRVal, false, _) => addEnumerator(E, X, Pr)
+
+     // Fixed enumerator. TODO check that the value fits into the UT
+     rule declareEnumerator(E::EnumId, X::CId, prv(V::CPPValue, Tr::Trace, _), true, UT::CPPIntegerType) => addEnumerator(E, X, prv(V, Tr, UT))
+
+     syntax KItem ::= addEnumerator(enum: EnumId, id: CId, v: PRVal)
+     rule <k> addEnumerator(E::EnumId, X::CId, V::PRVal) => addEnumeratorToEnv(E, X) ... </k>
+         <enum-id> E </enum-id>
+         <enumerators> ES::Map => ES[X <- V] </enumerators>
+
+     syntax KItem ::= addEnumeratorToEnv(EnumId, CId)
+
+     rule <k> addEnumeratorToEnv(E::EnumId, _) => . ... </k>
+          <enum-id> E </enum-id>
+          <scoped> true </scoped>
+
+     rule <k> addEnumeratorToEnv(enumId(N::Namespace :: Enum(_)) #as EId::EnumId, X::CId) => addUnscopedEnumeratorToNamespace(X, EId, N) ...</k>
+          <curr-tu> Tu::String </curr-tu>
+          <tu-id> Tu </tu-id>
+          <enum-id> EId </enum-id>
+          <scoped> false </scoped>
+
+     syntax KItem ::= addUnscopedEnumeratorToNamespace(CId, EnumId, Namespace)
+
+     rule <k> addUnscopedEnumeratorToNamespace(X::CId, enumId(E::Enum), N::Namespace) => . ... </k>
+          <curr-tu> Tu::String </curr-tu>
+          <tu-id> Tu </tu-id>
+          <ns-id> N </ns-id>
+          <unscoped-enumerators> UE::Map (.Map => X |-> E ) </unscoped-enumerators>
+
+     syntax CPPSimpleType ::= chooseEnumeratorType(CPPSimpleType, Int) [function]
+     rule chooseEnumeratorType(T::CPPSimpleType, Val::Int) => #if inRange(Val, type(T)) #then T #else firstSuitableType(Val, Val, allIntegralTypes) #fi
+
+     // For unscoped enums without fixed type,
+     // compute their minimal and maximal value
+     // as well as their underlying type
+
+     // Possible underlying types according to 7.2:7
+     syntax List ::= "integralTypesGreaterThanInt" [function]
+     rule integralTypesGreaterThanInt
+          => ListItem(int)
+             ListItem(unsigned)
+             ListItem(long)
+             ListItem(unsigned-long)
+             ListItem(long-long)
+             ListItem(unsigned-long-long)
+
+     //
+     syntax List ::= "allIntegralTypes" [function]
+     rule allIntegralTypes
+          => ListItem(signed-char)
+             ListItem(unsigned-char)
+             ListItem(short)
+             ListItem(unsigned-short)
+             integralTypesGreaterThanInt
+
+
+     
+     syntax CPPSimpleType ::= firstSuitableType(Int, Int, List) [function]
+     rule firstSuitableType(Min::Int, Max::Int, ListItem(T::CPPSimpleType) _) => T
+          requires Min >=Int min(type(T)) andBool Max <=Int max(type(T))
+     rule firstSuitableType(_, _, .List) => int
+     rule firstSuitableType(_, _, (ListItem(_) => .List) _) [owise]
+
+
+     syntax KItem ::= calculateEnumValues(CPPEnumType, min: Int, max: Int)
+
+     syntax Int ::= calculateMaxEnumValue(emin: Int, emax: Int) [function]
+     syntax Int ::= calculateMinEnumValue(emin: Int, emax: Int) [function]
+
+     rule calculateMinEnumValue(EMin::Int, _) => 0
+     requires EMin >=Int 0
+
+     rule calculateMinEnumValue(EMin::Int, EMax::Int) => 0 -Int (calculateMaxEnumValue(EMin, EMax) +Int 1) [owise]
+
+     rule calculateMaxEnumValue(EMin::Int, EMax::Int) => firstGreaterThanOrEqualTo(0, maxInt(absInt(EMin) -Int 1, absInt(EMax)))
+
+
+     syntax Int ::= firstGreaterThanOrEqualTo(exp: Int, tresh: Int) [function]
+
+     rule firstGreaterThanOrEqualTo(Exp::Int, Tresh::Int) => (1 <<Int Exp) -Int 1
+     requires ((1 <<Int Exp) -Int 1) >=Int Tresh
+
+     rule firstGreaterThanOrEqualTo(Exp::Int, Tresh::Int) => firstGreaterThanOrEqualTo(Exp +Int 1, Tresh) [owise]
+
+     rule calculateEnumValues(T::CPPEnumType, Min::Int, Max::Int) => computeEnumUt(T, calculateMinEnumValue(Min, Max), calculateMaxEnumValue(Min, Max))
+
+     syntax KItem ::= computeEnumUt(CPPEnumType, min: Int, max: Int)
+
+     // TODO(h0nzZik): packed enums
+     rule computeEnumUt(T::CPPEnumType, Min::Int, Max::Int) => setEnumMinMaxUt(T, Min, Max, type(firstSuitableType(Min, Max, integralTypesGreaterThanInt)))
+
+     syntax KItem ::= setEnumMinMaxUt(CPPEnumType, min: Int, max: Int, ut: CPPType)
+
+     rule <k> setEnumMinMaxUt(t(_, _, unscopedEnum(enumId(_ :: Enum(X::CId)) #as E::EnumId, _, _)), Min::Int, Max::Int, UT:CPPIntegerType)
+          => addEnumToEnv(X, t(noQuals, .Set, unscopedEnum(E, UT, false))) ... </k>
+          <enum-id> E </enum-id>
+          <enum-type> _ => t(noQuals, .Set, unscopedEnum(E, UT, false)) </enum-type>
+          <enum-min> _ => Min </enum-min>
+          <enum-max> _ => Max </enum-max>
+          <enum-complete> _ => true </enum-complete>
+
 
 endmodule
 

--- a/semantics/cpp14/language/translation/decl/enum.k
+++ b/semantics/cpp14/language/translation/decl/enum.k
@@ -113,15 +113,16 @@ module CPP-DECL-ENUM
           declareEnumerators(_, _, _, Next::Int, PrevType::CPPSimpleType, ListItem(Enumerator(_, NoExpression())) _::List, false, false)
           requires notBool inRange(Next, type(PrevType)) andBool firstSuitableType(Next, Next, allIntegralTypes) ==K no-type
 
-     rule declareEnumerators(_, _, _, _, _, ListItem(Enumerator(_, prv(_, _, T:CPPEnumType => underlyingType(T)))) _::List, _, _)
+     rule declareEnumerators(_, _, _, _, _, ListItem(Enumerator(_, prv(_, _, T:CPPUnscopedEnumType => underlyingType(T)))) _::List, _, _)
      context declareEnumerators(_, _, _, _, _, ListItem(Enumerator(_, HOLE:Expr)) _::List, _, _)
 
      // Type of an enumerator inside the declaration is enum's underlying type
      // if it is fixed, and type of initializing expression otherwise,
      // Hence we need to store the type of underlying expression...
-     rule declareEnumerators(T::CPPEnumType, Min::Int, Max::Int, Next::Int, _, ListItem(Enumerator(X::CId, prv(V::Int, _, t(_, _, EType::CPPSimpleType)) #as Pr::PRVal)) L::List, Fixed:Bool, First:Bool)
+     rule declareEnumerators(T::CPPEnumType, Min::Int, Max::Int, Next::Int, _, ListItem(Enumerator(X::CId, prv(V::Int, _, t(_, _, EType:CPPSimpleType)) #as Pr::PRVal)) L::List, Fixed:Bool, First:Bool)
           => declareEnumerator(getEnumId(T), X, Pr, Fixed, underlyingType(T))
           ~> declareEnumerators(T, #if First #then V #else minInt(Min, V) #fi, #if First #then V #else maxInt(Max, V) #fi, V +Int 1, EType, L, Fixed, false)
+     requires notBool isCPPSimpleUnscopedEnumType(EType)
 
      // Enums with fixed underlying type are finished by now.
      rule declareEnumerators(T::CPPEnumType, _, _, _, _, .List, true, _) => .

--- a/semantics/cpp14/language/translation/name.k
+++ b/semantics/cpp14/language/translation/name.k
@@ -398,6 +398,12 @@ module CPP-TRANSLATION-NAME
      // 3.4.2:2.2
      rule getAssociatedNamespaces(ListItem(t(... st: classType(_ :: Class(_, _, Args::TemplateParams))) #as T::CPPClassType) L::List, B::NamespacesCell)
           => getAssociatedNamespaces(getTemplateArgTypes(Args) L, B) #getAssociatedNamespaces(List2Set(mapList(getAssociatedClasses(T), #klabel(`getInnermostNamespace1`))), B)
+     // 3.4.2:2.3
+     rule getAssociatedNamespaces(ListItem(t(_, _, scopedEnum(enumId(N::Namespace :: _), _))) L::List, B::NamespacesCell)
+          => getAssociatedNamespaces(L, B) #getAssociatedNamespaces(SetItem(N), B)
+     rule getAssociatedNamespaces(ListItem(t(_, _, unscopedEnum(enumId(N::Namespace :: _), _, _))) L::List, B::NamespacesCell)
+          => getAssociatedNamespaces(L, B) #getAssociatedNamespaces(SetItem(N), B)
+
      // 3.4.2:2.4
      rule getAssociatedNamespaces(ListItem(T::CPPType => innerType(T)) _, _)
           requires isCPPPointerType(T) orBool isCPPArrayType(T)

--- a/semantics/cpp14/language/translation/name.k
+++ b/semantics/cpp14/language/translation/name.k
@@ -48,11 +48,18 @@ module CPP-TRANSLATION-NAME
                    | nameLookupInFullNamespace(CId, MaybeNNS, Tag, isnns: Bool)
                    | nameLookupInNamespaceScope(CId, NNS, Tag, isnns: Bool)
                    | nameLookupInNamespaces(CId, set: Set, Tag, isnns: Bool, result: Expr)
+                   | nameLookupInEnumScope(CId, Tag, isnns: Bool, EnumScope)
+                   | nameLookupInScope(CId, Tag, isnns: Bool, scope: Scope)
+                   | lookupEnumerator(CId, Enum)
 
      syntax Namespace ::= getInnermostNamespace(Scope) [function, klabel(getInnermostNamespace1)]
      rule getInnermostNamespace(blockScope(N:Namespace :: _, _, _)) => N
      rule getInnermostNamespace(classScope(N:Namespace :: _)) => N
      rule getInnermostNamespace(namespaceScope(N::Namespace)) => N
+     rule getInnermostNamespace(enumScope(enumId(N:Namespace :: _))) => N
+
+     syntax Scope ::= getRestOfScope(EnumScope) [function]
+     rule getRestOfScope(enumScope(enumId(N:Namespace :: _))) => namespaceScope(N)
 
      // name lookup in namespace scope
      rule <k> nameLookupInNamespaceScope(X::CId, N::Namespace, Tag::Tag, IsNNS::Bool)
@@ -73,13 +80,22 @@ module CPP-TRANSLATION-NAME
             R::Expr => cSetUnion(nameLookupInNamespace(X, N, Tag, IsNNS), R))
 
      // name lookup in a single namespace
+     rule <k> nameLookupInNamespace(X::CId, N::Namespace, NoTag(), false) => lookupEnumerator(X, E)  ...</k>
+          <curr-tu> Tu::String </curr-tu>
+          <tu-id> Tu </tu-id>
+          <ns-id> N </ns-id>
+          <unscoped-enumerators>... X |-> E::Enum ...</unscoped-enumerators>
+          <templates> T::Map </templates>
+          requires notBool N :: X in_keys(T)
+
      rule <k> nameLookupInNamespace(X::CId, N::Namespace, NoTag(), false) => cSet(M, N :: X, .K) ...</k>
           <curr-tu> Tu::String </curr-tu>
           <tu-id> Tu </tu-id>
           <ns-id> N </ns-id>
           <nenv>... X |-> M::Map ...</nenv>
           <templates> T::Map </templates>
-          requires notBool N :: X in_keys(T)
+          <unscoped-enumerators> UE::Map </unscoped-enumerators>
+          requires notBool N :: X in_keys(T) andBool notBool X in_keys(UE)
 
      rule <k> nameLookupInNamespace(X::CId, N::Namespace, NoTag(), _) => nsRef(NS) ...</k>
           <curr-tu> Tu::String </curr-tu>
@@ -147,6 +163,23 @@ module CPP-TRANSLATION-NAME
           <types> Types::Map </types>
           requires (notBool X in_keys(Env) orBool IsNNS)
            andBool notBool X in_keys(Types)
+
+     rule <k> lookupEnumerator(X::CId, E::Enum) => V ... </k>
+          <curr-scope> enumScope(enumId(E)) </curr-scope>
+          <enum-id> enumId(E) </enum-id>
+          <enumerators>... X |-> V::PRVal </enumerators>
+
+     rule <k> lookupEnumerator(X::CId, E::Enum) => prv(V, Tr, ET) ... </k>
+          <curr-scope> Sc::Scope </curr-scope>
+          <enum-id> enumId(E) </enum-id>
+          <enum-type> ET::CPPType </enum-type>
+          <enumerators>... X |-> prv(V::CPPValue, Tr::Trace, _) </enumerators>
+          requires Sc =/=K enumScope(enumId(E))
+
+     rule <k> lookupEnumerator(X::CId, E::Enum) => notFound(X) ...</k>
+          <enum-id> enumId(E) </enum-id>
+          <enumerators> Enumerators::Map </enumerators>
+          requires notBool X in_keys(Enumerators)
 
      // lookup member in class (and base-classes)
      rule <k> lookupMember(X::CId, C::Class, NoTag(), false) => classSet(C, X, S) ...</k>
@@ -233,6 +266,7 @@ module CPP-TRANSLATION-NAME
 
      rule qualifiedNameLookup(X::CId, N:Namespace, IsNNS::Bool) => nameLookupInNamespaceScope(X, N, NoTag(), IsNNS)
      rule qualifiedNameLookup(X::CId, C:Class, IsNNS::Bool) => lookupMember(X, C, NoTag(), IsNNS)
+     rule qualifiedNameLookup(X::CId, E:Enum, IsNNS::Bool) => lookupEnumerator(X::CId, E)
 
      rule Name(N::NNS, X::CId)
        => resolveUniqueDecl(#if N ==K NoNNS()
@@ -260,6 +294,8 @@ module CPP-TRANSLATION-NAME
      syntax KItem ::= extractNNS(K) [strict]
      rule extractNNS(nsRef(N::Namespace)) => N
      rule extractNNS(t(_, _, classType(C::Class))) => C
+     rule extractNNS(t(_, _, scopedEnum(enumId(E::Enum), _))) => E
+     rule extractNNS(t(_, _, unscopedEnum(enumId(E::Enum), _, _))) => E
 
      syntax Expr ::= argDependentNameLookup(CId, StrictList, StrictList, Expr) [strict(4)]
                    | #argDependentNameLookup(CId, StrictList, List, Set, CandidateSet)
@@ -268,16 +304,28 @@ module CPP-TRANSLATION-NAME
                     | resolveElabSpecifier(K, StrictList) [strict(1, 2), klabel(resolveElabSpecifier2)]
                     | specializeTypeTemplate(QualId, CPPType, List)
 
-     rule <k> nameLookup(X::CId, Tag::Tag, IsNNS::Bool) => lookupNameInFullClass(X, classFromScope(Scope), isBlockScope(Scope), Tag, IsNNS) ...</k>
+     rule <k> nameLookup(X::CId, Tag::Tag, IsNNS::Bool) => nameLookupInScope(X, Tag, IsNNS, Scope) ...</k>
           <curr-scope> Scope::Scope </curr-scope>
+
+     rule <k> nameLookupInScope(X::CId, Tag::Tag, IsNNS::Bool, Scope::Scope) => lookupNameInFullClass(X, classFromScope(Scope), isBlockScope(Scope), Tag, IsNNS) ...</k>
           requires inClassScope(Scope)
 
+     rule nameLookupInScope(X::CId, Tag::Tag, IsNNS::Bool, enumScope(E::EnumId)) => nameLookupInEnumScope(X, Tag, IsNNS, enumScope(E))
+
      // 3.4.1: 6
-     rule <k> nameLookup(X::CId, Tag::Tag, IsNNS::Bool) => lookupNameInBlock(X, Tag, IsNNS)
+     rule nameLookupInScope(X::CId, Tag::Tag, IsNNS::Bool, Scope::Scope) => lookupNameInBlock(X, Tag, IsNNS)
                                  orIfNotFound nameLookupInFullNamespace(X, getInnermostNamespace(Scope), Tag, IsNNS)
-          ...</k>
-          <curr-scope> Scope::Scope </curr-scope>
-          requires notBool inClassScope(Scope)
+          requires notBool inClassScope(Scope) andBool notBool isEnumScope(Scope)
+
+     rule <k> nameLookupInEnumScope(X::CId, _, _, enumScope(E::EnumId)) => V ... </k>
+          <enum-id> E </enum-id>
+          <enumerators>... X |-> V::PRVal ...</enumerators>
+
+     rule <k> nameLookupInEnumScope(X::CId, Tag::Tag, IsNNS::Bool, enumScope(E::EnumId)) => nameLookupInScope(X, Tag, IsNNS, getRestOfScope(enumScope(E))) ... </k>
+          <enum-id> E </enum-id>
+          <enumerators> Enumerators::Map </enumerators>
+          requires notBool X in_keys(Enumerators)
+
 
      // arg dependent name lookup
      context argDependentNameLookup(_, _, (HOLE:StrictList => types(HOLE)), _)

--- a/semantics/cpp14/language/translation/name.k
+++ b/semantics/cpp14/language/translation/name.k
@@ -307,7 +307,7 @@ module CPP-TRANSLATION-NAME
      rule <k> nameLookup(X::CId, Tag::Tag, IsNNS::Bool) => nameLookupInScope(X, Tag, IsNNS, Scope) ...</k>
           <curr-scope> Scope::Scope </curr-scope>
 
-     rule <k> nameLookupInScope(X::CId, Tag::Tag, IsNNS::Bool, Scope::Scope) => lookupNameInFullClass(X, classFromScope(Scope), isBlockScope(Scope), Tag, IsNNS) ...</k>
+     rule nameLookupInScope(X::CId, Tag::Tag, IsNNS::Bool, Scope::Scope) => lookupNameInFullClass(X, classFromScope(Scope), isBlockScope(Scope), Tag, IsNNS)
           requires inClassScope(Scope)
 
      rule nameLookupInScope(X::CId, Tag::Tag, IsNNS::Bool, enumScope(E::EnumId)) => nameLookupInEnumScope(X, Tag, IsNNS, enumScope(E))

--- a/semantics/cpp14/language/translation/syntax.k
+++ b/semantics/cpp14/language/translation/syntax.k
@@ -16,6 +16,8 @@ module CPP-ABSTRACT-SYNTAX
      imports CPP-DEPENDENT-SYNTAX
      imports CPP-CLASS-SYNTAX
 
+     syntax CPPIntegerType
+
      syntax LVal ::= LExpr
      syntax XVal ::= XExpr
      syntax PRVal ::= PRExpr
@@ -82,7 +84,8 @@ module CPP-ABSTRACT-SYNTAX
 
      syntax Decl ::= ClassDef(Tag, CId, NNS, List, List)
                    | TypeDecl(AType)
-                   | EnumDef(CId, NNS, List)
+                   | EnumDef(id: CId, nns: NNS, scoped: Bool, fixed: Bool, ut: AType, List) [strict(5)]
+                   | OpaqueEnumDeclaration(id: CId, scoped: Bool, ut: AType)
                    | AccessSpec(AccessSpecifier)
                    | StaticAssert(Expr, Expr)
                    | UsingDecl(Bool, NNS, CId)

--- a/semantics/cpp14/language/translation/translation.k
+++ b/semantics/cpp14/language/translation/translation.k
@@ -16,6 +16,7 @@ require "configuration.k"
 
 require "decl/class.k"
 require "decl/declarator.k"
+require "decl/enum.k"
 require "decl/initializer.k"
 require "decl/linkage.k"
 require "decl/namespace.k"
@@ -75,6 +76,7 @@ module CPP-TRANSLATION
      imports CPP-VALUE-CATEGORY
 
      imports CPP-DECL-CLASS
+     imports CPP-DECL-ENUM
      imports CPP-DECL-DECLARATOR
      imports CPP-DECL-INITIALIZER
      imports CPP-DECL-LINKAGE

--- a/tests/unit-pass/enum-empty.C
+++ b/tests/unit-pass/enum-empty.C
@@ -1,0 +1,13 @@
+extern "C" void abort();
+
+enum E : int {};
+
+E e;
+
+int main() {
+	E f = e;
+	E * g = nullptr;
+
+	if (sizeof(e) != sizeof(int))
+		abort();
+}

--- a/tests/unit-pass/enum-values.C
+++ b/tests/unit-pass/enum-values.C
@@ -1,0 +1,84 @@
+/*
+ * Tests enum values. Only values inside the range are tested,
+ * and lines which should cause runtime error are commented out.
+ */
+
+// b_max >= max(-1, 1) = 1
+// b_max = 1
+// b_min = 0
+enum E {
+	E_0, E_1
+};
+
+// b_max >= max(-1, 4) = 4
+// b_max = 7
+// b_min = 0
+enum F {
+	F_4 = 4, F_0 = 0
+};
+
+// b_max >= max(0, 1) = 1
+// b_max = 1
+// b_min = -(1 + 1) = -2
+enum G {
+	G_1 = -1
+};
+
+// b_max >= max(1, 2) = 2
+// b_max = 3
+// b_min = -(3 + 1) = -4
+enum H {
+	H_2 = -2
+};
+
+void test_E(int value)
+{
+	E e = (E)value;
+}
+
+void test_F(int value)
+{
+	F f = (F)value;
+}
+
+void test_G(int value)
+{
+	G g = (G)value;
+}
+
+void test_H(int value)
+{
+	H h = (H)value;
+}
+
+int main()
+{
+	test_E(0);
+	test_E(1);
+	//test_E(2); // fails, out of range
+	//test_E(-1); // similarly
+
+	test_F(0);
+	test_F(1);
+	test_F(2);
+	test_F(3);
+	test_F(4);
+	test_F(5);
+	test_F(6);
+	test_F(7);
+	//test_F(8);
+	//test_F(-1);
+	
+	test_G(-2);
+	test_G(-1);
+	test_G(0);
+	test_G(1);
+	//test_G(-3);
+	//test_G(2);
+	
+	for (int i = -4; i <= 3; i++)
+		test_H(i);
+
+	//test_H(-5);
+	//test_H(4);
+}

--- a/tests/unit-pass/enumerators.C
+++ b/tests/unit-pass/enumerators.C
@@ -90,6 +90,37 @@ void check_6()
 	assert((int)sizeof_E6_A == (int)sizeof_E6_B);
 }
 
+enum E7
+{
+	E7_A = 0ull,
+	E7_B = sizeof(E7_A)
+};
+
+void check_7()
+{
+	// Type of E7_A inside the enumeration
+	// should be 'unsigned long long'
+	assert((int)E7_B == sizeof(unsigned long long));
+}
+
+enum E8 : int
+{
+	E8_A = 10
+};
+
+enum E9
+{
+	// Type of E9_A here should be
+	// the underlying type of E8, which is 'int'
+	E9_A = E8_A,
+	E9_B = sizeof(E9_A)
+};
+
+void check_8()
+{
+	assert((int)E9_B == sizeof(int));
+}
+
 int main()
 {
 
@@ -99,6 +130,8 @@ int main()
 	check_4();
 	check_5();
 	check_6();
+	check_7();
+	check_8();
 
 	return 0;
 }

--- a/tests/unit-pass/enumerators.C
+++ b/tests/unit-pass/enumerators.C
@@ -1,0 +1,105 @@
+/**
+ * Tests enumerator values and types.
+ */
+
+#include <limits.h>
+
+extern "C" void abort();
+#define assert(x) if(!(x)) abort()
+
+enum Empty{};
+enum WithZero { Zero = 0 };
+
+void check_1()
+{
+	// Consequence of 7.2:7
+	assert(sizeof(Empty) == sizeof(WithZero));
+}
+
+enum class E1 {
+	A=3,       // 3
+	B=E1::A-1,  // 2
+	C=4*B-A    // 5
+};
+
+void check_2()
+{
+	assert(((int)E1::A) == 3);
+	assert((int)E1::B == 2);
+	assert((int)E1::C == 5);
+}
+
+enum E2
+{
+	E2_A = UINT_MAX, // type: unsigned
+	E2_B, // type: > unsigned (e.g. long) due to 7.2:5.3
+	sizeof_E2_A = sizeof(E2_A),
+	sizeof_E2_B = sizeof(E2_B)
+};
+
+void check_3()
+{
+	assert((int)sizeof_E2_A < (int)sizeof_E2_B);
+}
+
+enum class E3 {
+	D=sizeof(E3) // sizeof(int), which is the implicit underlying type
+};
+
+enum E4 : int {
+	E=sizeof(E4) // sizeof(int)
+};
+
+void check_4()
+{
+	assert((int)E3::D == sizeof(int));
+	assert((int)E4::E == sizeof(int));
+}
+
+enum E5 {
+	// F=sizeof(E5) // should not pass, this is an incomplete type
+	G = 'a',
+	H = sizeof(G), // 1, because here the type of G is the type of 'a'
+	J,K,
+	_last_E5 = 65535
+};
+
+void check_5()
+{
+	// Here the type of E5::G is E5
+	assert(sizeof(E5::G) >= 2);
+	assert(sizeof(E5::G) == sizeof(E5));
+	assert((int)E5::H == sizeof(char));
+	assert((int)E5::J == 2);
+	assert((int)E5::K == 3);
+}
+
+enum E6
+{
+	// The type is 'char'
+	E6_A = 'a',
+	// The type is 'char' again (7.2:5.3)
+	E6_B,
+
+	sizeof_E6_A = sizeof(E6_B),
+	sizeof_E6_B = sizeof(E6_B)
+};
+
+void check_6()
+{
+	assert((int)sizeof_E6_A == (int)sizeof_E6_B);
+}
+
+int main()
+{
+
+	check_1();
+	check_2();
+	check_3();
+	check_4();
+	check_5();
+	check_6();
+
+	return 0;
+}
+


### PR DESCRIPTION
Implements: enums, enumerators, their underlying type, lookup.

Does not implement: enums in functions/classes, std::underlying_type, opaque enums.

Depends on:
https://github.com/kframework/c-semantics/pull/270.
https://github.com/kframework/c-semantics/pull/268

Closes https://github.com/kframework/c-semantics/pull/262