### PR TITLE
missing cfg:alignofReference

### DIFF
--- a/x86-gcc-limited-libc/cpp-semantics/cpp-settings.k
+++ b/x86-gcc-limited-libc/cpp-semantics/cpp-settings.k
@@ -14,6 +14,8 @@ module CPP-SETTINGS
      rule cfg:memberFunctionPtrSize => 8
      rule cfg:memberDataPtrAlign => 4
      rule cfg:memberFunctionPtrAlign => 8
+     rule cfg:alignofReference => 4
+
 endmodule
 
 module CPP-COMPILER-SETTINGS


### PR DESCRIPTION
The rule for cfg:alignofReference was missing. Test: `tests/unit-pass/init-ref2.C`.