### PR TITLE
Clang-Kast: What if presumed location is not valid?

### DIFF
--- a/cpp-parser/ClangKast.cc
+++ b/cpp-parser/ClangKast.cc
@@ -174,7 +174,7 @@ bool TraverseDecl(Decl *D) {
   void AddCabsLoc(SourceLocation loc) {
     SourceManager &mgr = Context->getSourceManager();
     PresumedLoc presumed = mgr.getPresumedLoc(loc);
-    const char *filename = presumed.getFilename();
+    const char *filename = presumed.isValid()? presumed.getFilename() : nullptr;
     if (filename) {
       AddKApplyNode("CabsLoc", 5);
       AddKTokenNode(escape(presumed.getFilename(), strlen(presumed.getFilename())), "String");


### PR DESCRIPTION
`SourceManager::getPresumedLoc()` may return invalid location, which actually happens on my system.