### PR TITLE
Fix base class access

### DIFF
--- a/semantics/cpp14/language/common/expr/members.k
+++ b/semantics/cpp14/language/common/expr/members.k
@@ -3,7 +3,7 @@ module CPP-EXPR-MEMBERS-SYNTAX
      imports CPP-SORTS
      imports CPP-DYNAMIC-SORTS
      imports CPP-TYPING-SORTS
-     syntax Expr ::= fieldExp(Expr, Name, CPPType, Int) [strict(1)]
+     syntax Expr ::= fieldExp(Expr, CPPType, Int) [strict(1)]
 endmodule
 
 module CPP-EXPR-MEMBERS
@@ -28,8 +28,8 @@ module CPP-EXPR-MEMBERS
 
      syntax KItem ::= lookupFieldCPP(Val, CPPType, Name, Int)
      //TODO(traiansf): Check access permissions
-     rule <k> lookupFieldCPP(V::Val, TC::CPPType, Name(FC::Class, F::CId) #as N::Name, PrevOffset::Int)
-           => fieldExp(V, N, addQuals(getQuals(type(V)), T), Offset +Int PrevOffset)
+     rule <k> lookupFieldCPP(V::Val, TC::CPPType, Name(FC::Class, F::CId), PrevOffset::Int)
+           => fieldExp(V, addQuals(getQuals(type(V)), T), Offset +Int PrevOffset)
           ...</k>
           <class-id> FC </class-id>
           <cenv>... F |-> (T::CPPType |-> classOffset(Offset::Int)) ...</cenv>
@@ -45,7 +45,7 @@ module CPP-EXPR-MEMBERS
           <class-id> FC </class-id>
           <cenv>... F |-> (_::CPPType |-> envEntry(... base: memberBase(unnamedObject(C::Class), _, _))) unnamedObject(C) |-> (_::CPPType |-> classOffset(Offset::Int)) ...</cenv>
 
-     rule fieldExp(lv(Loc:SymLoc, _, _), _, T::CPPType, Offset::Int)
+     rule fieldExp(lv(Loc:SymLoc, _, _), T::CPPType, Offset::Int)
           => lv(Loc +bytes Offset /Int cfg:bitsPerByte, noTrace, T)
           requires notBool isCPPBitfieldType(T)
 

--- a/semantics/cpp14/language/common/expr/members.k
+++ b/semantics/cpp14/language/common/expr/members.k
@@ -24,17 +24,24 @@ module CPP-EXPR-MEMBERS
      context HOLE:Expr . _ _
 
      rule V:Val . no-template (Name(_:Class, _) #as N::Name)
-       => lookupFieldCPP(V, N, 0)
+       => lookupFieldCPP(V, type(V), N, 0)
 
-     syntax KItem ::= lookupFieldCPP(Val, Name, Int)
+     syntax KItem ::= lookupFieldCPP(Val, CPPType, Name, Int)
      //TODO(traiansf): Check access permissions
-     rule <k> lookupFieldCPP(V::Val, Name(FC::Class, F::CId) #as N::Name, PrevOffset::Int)
+     rule <k> lookupFieldCPP(V::Val, TC::CPPType, Name(FC::Class, F::CId) #as N::Name, PrevOffset::Int)
            => fieldExp(V, N, addQuals(getQuals(type(V)), T), Offset +Int PrevOffset)
           ...</k>
           <class-id> FC </class-id>
           <cenv>... F |-> (T::CPPType |-> classOffset(Offset::Int)) ...</cenv>
+          requires type(simpleType(TC)) ==Type type(classType(FC))
 
-     rule <k> lookupFieldCPP(V::Val, Name(FC::Class => C, F::CId), PrevOffset::Int => PrevOffset +Int Offset) ...</k>
+     rule <k> lookupFieldCPP(V::Val, t(... st: classType(DC::Class => BC)), Name(BC::Class, _), PrevOffset::Int => PrevOffset +Int Offset)
+          ...</k>
+          <class-id> DC </class-id>
+          <cenv>... baseClass(BC)  |-> (_ |-> classOffset(Offset::Int)) ...</cenv>
+          requires isBaseClassOf(BC, DC)
+
+     rule <k> lookupFieldCPP(V::Val, _, Name(FC::Class => C, F::CId), PrevOffset::Int => PrevOffset +Int Offset) ...</k>
           <class-id> FC </class-id>
           <cenv>... F |-> (_::CPPType |-> envEntry(... base: memberBase(unnamedObject(C::Class), _, _))) unnamedObject(C) |-> (_::CPPType |-> classOffset(Offset::Int)) ...</cenv>
 

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -277,6 +277,8 @@ module CPP-TYPING-SYNTAX
 
      syntax CPPType ::= implicitObjectParameterType(CPPFunctionType) [function]
 
+     syntax LVal ::= getBaseClassSubobject(base: LVal, baseType: CPPClassType) [strict]
+
      syntax Bool ::= isBaseClassOf(base: CPPClassType, derived: CPPClassType) [function]
                    | isVirtualBaseClassOf(CPPClassType, CPPClassType) [function]
                    | isBaseClassOf(base: Class, derived: Class) [function, klabel(isClassBaseClassOf)]
@@ -654,6 +656,9 @@ module CPP-TYPING
      rule isUnnamedPRValue(T::CPPType) 
           => notBool isUnnamedLValue(T) andBool notBool isUnnamedXValue(T)
     
+     rule getBaseClassSubobject(lv(L::SymLoc, Tr::Trace, D::CPPClassType), B::CPPClassType) => lv(baseClassSubobject(L, B, D), Tr, B)
+     rule type(getBaseClassSubobject(_::LVal, B::CPPClassType)) => B
+
      rule isBaseClassOf(t(_, _, classType(B::Class)), t(_, _, classType(D::Class))) => isBaseClassOf(B, D)
      rule isBaseClassOf(B::Class, D::Class) => #isBaseClassOf(B, ListItem(D), #configuration)
      rule isDirectBaseClassOf(B::Class, D::Class) => #isDirectBaseClassOf(B, D, #configuration)

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -39,6 +39,7 @@ module CPP-TYPING-SYNTAX
      imports COMMON-SORTS
      imports CPP-DYNAMIC-SORTS
      imports CPP-SORTS
+     imports CPP-SYMLOC-SYNTAX
 
      syntax AType ::= CPPType
 

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -278,7 +278,7 @@ module CPP-TYPING-SYNTAX
 
      syntax CPPType ::= implicitObjectParameterType(CPPFunctionType) [function]
 
-     syntax LVal ::= getBaseClassSubobject(base: LVal, baseType: CPPClassType) [strict]
+     syntax Expr ::= getBaseClassSubobject(base: LVal, baseType: CPPClassType) [strict]
 
      syntax Bool ::= isBaseClassOf(base: CPPClassType, derived: CPPClassType) [function]
                    | isVirtualBaseClassOf(CPPClassType, CPPClassType) [function]
@@ -658,7 +658,6 @@ module CPP-TYPING
           => notBool isUnnamedLValue(T) andBool notBool isUnnamedXValue(T)
     
      rule getBaseClassSubobject(lv(L::SymLoc, Tr::Trace, D::CPPClassType), B::CPPClassType) => lv(baseClassSubobject(L, B, D), Tr, B)
-     rule type(getBaseClassSubobject(_::LVal, B::CPPClassType)) => B
 
      rule isBaseClassOf(t(_, _, classType(B::Class)), t(_, _, classType(D::Class))) => isBaseClassOf(B, D)
      rule isBaseClassOf(B::Class, D::Class) => #isBaseClassOf(B, ListItem(D), #configuration)

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -39,7 +39,7 @@ module CPP-TYPING-SYNTAX
      imports COMMON-SORTS
      imports CPP-DYNAMIC-SORTS
      imports CPP-SORTS
-     imports CPP-SYMLOC-SYNTAX
+     imports CPP-SYMLOC-SORTS
 
      syntax AType ::= CPPType
 
@@ -328,6 +328,7 @@ module CPP-TYPING
      imports CPP-CLASS-SYNTAX
      imports CPP-DYNAMIC-SYNTAX
      imports CPP-SYNTAX
+     imports CPP-SYMLOC-SYNTAX
 
      rule getParams(t(_, _, functionType(... paramTypes: L::CPPTypes, methodInfo: noMethod))) => toList(L)
      rule getParams(t(_, _, functionType(... paramTypes: L::CPPTypes, methodInfo: methodInfo(... constructor: true)))) => toList(L)

--- a/semantics/cpp14/language/common/typing.k
+++ b/semantics/cpp14/language/common/typing.k
@@ -39,7 +39,7 @@ module CPP-TYPING-SYNTAX
      imports COMMON-SORTS
      imports CPP-DYNAMIC-SORTS
      imports CPP-SORTS
-     imports CPP-SYMLOC-SORTS
+     imports SYMLOC-SORTS
 
      syntax AType ::= CPPType
 

--- a/semantics/cpp14/language/execution/expr/reference.k
+++ b/semantics/cpp14/language/execution/expr/reference.k
@@ -12,14 +12,19 @@ module CPP-EXPR-REFERENCE
      // we need this result tag because lvalues of reference type aren't KResults
      context bindReference(HOLE:Expr, _) [result(LVal)]
 
+     syntax SymLoc ::= referenceTarget(t1: CPPType, loc: SymLoc, t2: CPPType) [function]
+     rule referenceTarget(T1:CPPClassType, Loc::SymLoc, T2:CPPClassType) => baseClassSubobject(Loc, T1, T2)
+          requires isBaseClassOf(T1, T2)
+     rule referenceTarget(... loc: Loc::SymLoc) => Loc [owise]
+
      rule <k> bindReference(lv(Loc1::SymLoc, Tr::Trace, T1::CPPType), lv(Loc2::SymLoc, _, T2::CPPType))
               => lv(Loc1, Tr, T1) ...</k>
-          <references>... .Map => stripProv(Loc1) |-> Loc2 ...</references>
+          <references>... .Map => stripProv(Loc1) |-> referenceTarget(innerType(T1), Loc2, T2) ...</references>
           requires isCPPLVRefType(T1) andBool notBool isCPPBitfieldType(T2) andBool isReferenceCompatible(innerType(T1), T2)
 
      rule <k> bindReference(lv(Loc1::SymLoc, Tr::Trace, T1::CPPRefType), xv(Loc2::SymLoc, _, T2::CPPType))
               => lv(Loc1, Tr, T1) ...</k>
-          <references>... .Map => stripProv(Loc1) |-> Loc2 ...</references>
+          <references>... .Map => stripProv(Loc1) |-> referenceTarget(innerType(T1), Loc2, T2) ...</references>
           requires notBool isCPPBitfieldType(T2)  andBool isReferenceCompatible(innerType(T1), T2) andBool isValidReferenceType(T1)
 
      rule <k> bindReference(lv(Loc::SymLoc, Tr1::Trace, T1::CPPType), prv(V::CPPValue, Tr2::Trace, T2::CPPType))

--- a/semantics/cpp14/language/translation/expr/members.k
+++ b/semantics/cpp14/language/translation/expr/members.k
@@ -8,6 +8,6 @@ module CPP-TRANSLATION-EXPR-MEMBERS
      context CallExpr(HOLE:Expr . _ _, _, _)
      context CallExpr(BinaryOperator(operator->, _, _) #as HOLE:Expr, _, _) [result(ResolvedExpr), structural]
 
-     rule fieldExp(E:LExpr, N::Name, T::CPPType, Offset::Int)
-          => le(fieldExp(E, N, T, Offset), trace(E), T)
+     rule fieldExp(E:LExpr, T::CPPType, Offset::Int)
+          => le(fieldExp(E, T, Offset), trace(E), T)
 endmodule

--- a/tests/unit-pass/two_bases.C
+++ b/tests/unit-pass/two_bases.C
@@ -1,0 +1,39 @@
+extern "C" void abort();
+#define assert(x) if(!(x)) abort();
+
+struct Base1 {
+	int x;
+
+	int const & getx() const {
+		return x;
+	}
+};
+
+struct Base2 {
+	int y;
+
+	int const & gety() const {
+		return y;
+	}
+};
+
+
+struct Derived : Base1, Base2 {
+
+};
+
+int main() {
+	Derived d;
+	d.x = 5;
+	d.y = 6;
+	assert(d.x == 5);
+
+	Base1 & b1 = d;
+	Base2 & b2 = d;
+
+	assert(&d.x == &b1.x);
+	assert(&b1.x != &b2.y);
+	assert(&d.x != &d.y);
+	assert(&d.y == &b2.y);
+	assert((void *)&b1 != (void *)&b2);
+}


### PR DESCRIPTION
Converting class instances to their base class as well as accessing an element of base class worked correctly only if:
- the class had only one base class.
- if the base class had no virtual function, then the derived class had no virtual function.

(I've discovered this when working on zero initialization of classes.)