### PR TITLE
Timestamp build log

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make "$@" | ./scripts/logger build.log

--- a/scripts/logger
+++ b/scripts/logger
@@ -1,0 +1,35 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use POSIX qw(strftime);
+use Term::ANSIColor;
+
+
+my $logFile;
+if(@ARGV >= 1) {
+  my $logFileName = $ARGV[0];
+  open(my $fw, '>', $logFileName) or die "Could not open file '$logFileName' $!";
+  $logFile = $fw;
+}
+
+sub finish {
+  if (defined $logFile) {
+    close $logFile;
+  }
+  exit;
+}
+$SIG{INT}  = \&finish;
+$SIG{TERM} = \&finish;
+
+while (my $inputLine = <STDIN>) {
+  my $prefix = strftime("[%Y-%m-%d %H:%M:%S]", localtime);
+  print colored(['yellow'], $prefix), " ", $inputLine;
+
+  if (defined $logFile) {
+    print $logFile $prefix, " ", $inputLine;
+  }
+}
+
+finish();
+


### PR DESCRIPTION
Produce nicer logs, with timestamps and colors.
```
$ ./build.sh
[2018-12-05 16:18:16] make[1]: Entering directory '/mnt/c/Users/jenda/linux_home/jan/git/h0nzZik/w/implicit-smf-1'
[2018-12-05 16:18:16] make[2]: Entering directory '/mnt/c/Users/jenda/linux_home/jan/git/h0nzZik/w/implicit-smf-1/semantics'
[2018-12-05 16:18:16] /mnt/c/Users/jenda/linux_home/jan/git/h0nzZik/w/implicit-smf-1/.build/k/k-distribution/target/release/k/bin/kdep -d ".build/x86-gcc-limited-libc/c11-nd-thread-kompiled" -I /mnt/c/Users/jenda/linux_home/jan/git/h0nzZik/w/implicit-smf-1/profiles/x86-gcc-limited-libc/semantics -I /mnt/c/Users/jenda/linux_home/jan/git/h0nzZik/w/implicit-smf-1/profiles/x86-gcc-limited-libc/semantics/c -I /mnt/c/Users/jenda/linux_home/jan/git/h0nzZik/w/implicit-smf-1/profiles/x86-gcc-limited-libc/semantics/cpp -- c11-cpp14.k > /tmp/tmp.rPBU0LIKCi
```

We may want to edit the Jenkins build such that
1. it runs `build.sh`
2. it stores `build.log`