### PR TITLE
Add lint production to OS semantics

### DIFF
--- a/semantics/common/options.k
+++ b/semantics/common/options.k
@@ -24,6 +24,7 @@ module OPTIONS-SYNTAX
      syntax Opt ::= RecoverAll()                      // Attempt recovery on all errors.
                   | InteractiveFail()                 // Enter interactive mode when recovery fails.
                   | FatalErrors()                     // Don't attempt any error recovery.
+                  | Lint()                            // Enable extra warnings.
 
      syntax String ::= showOpt(Opt) [function]
 
@@ -46,6 +47,7 @@ module OPTIONS
      rule showOpt(RecoverAll()) => "recover-all"
      rule showOpt(InteractiveFail()) => "interactive-fail"
      rule showOpt(FatalErrors()) => "fatal-errors"
+     rule showOpt(Lint()) => "lint"
      rule showOpt(Opt::Opt) => showK(Opt) [owise]
 
 endmodule


### PR DESCRIPTION
So the open source version of kcc doesn't crash when given the "-Wlint" flag.