### PR TITLE
Remove stdio.h from a cpp test.

### DIFF
--- a/tests/unit-pass/enum-operator.C
+++ b/tests/unit-pass/enum-operator.C
@@ -1,5 +1,3 @@
-#include<stdio.h>
-
 enum A : long {
   a, b, c
 };


### PR DESCRIPTION
The C++ semantics can't seem to handle the actual system stdio header right now and including the header here was unneeded and not what the test was intended to test.