### PR TITLE
DR 423, 481: semantics of generic and rval types.

### DIFF
--- a/semantics/c/language/common/expr/members.k
+++ b/semantics/c/language/common/expr/members.k
@@ -55,7 +55,7 @@ module C-COMMON-EXPR-MEMBERS
 
      // Same deal as above, only for byte lists.
      rule tv(agg(L:List), structOrUnionUType #as T::UType) . F:CId
-          => concretize(addModifiers(getModifiers(T) getModifiers(findFieldTypeU(F, T)), utype(findFieldTypeU(F, T))),
+          => concretize(addModifiers(getModifiers(T) getModifiers(findFieldTypeU(F, T)), rvalType(findFieldTypeU(F, T))),
                fillToBytes(extractBitsFromList(dataList(L), findFieldOffsetU(F, T), bitSizeofType(findFieldTypeU(F, T)))))
           requires notBool isNoType(findFieldTypeU(F, T))
           [structural]

--- a/semantics/c/language/common/memory/reading.k
+++ b/semantics/c/language/common/memory/reading.k
@@ -52,12 +52,12 @@ module C-MEMORY-READING
 
      syntax KItem ::= readActual(SymLoc, Type)
      rule readActual(Loc::SymLoc, T::Type)
-          => concretize(updateReadFrom(utype(T), Loc),
+          => concretize(updateReadFrom(rvalType(T), Loc),
                readBytes(Loc, byteSizeofType(T), T))
           requires notBool isBitfieldType(T)
           [structural]
      rule readActual(Loc::SymLoc, t(... st: bitfieldType(...)) #as T::Type)
-          => concretize(updateReadFrom(utype(T), Loc),
+          => concretize(updateReadFrom(rvalType(T), Loc),
               fillToBytes(extractBitsFromMem(Loc, T)))
           [structural]
 

--- a/semantics/c/language/common/typing.k
+++ b/semantics/c/language/common/typing.k
@@ -401,4 +401,7 @@ module C-TYPING-SYNTAX
      // updating the effective types of accesses.
      syntax Provenance ::= objectType(EffectiveType)
 
+     // Unqualify, array-to-pointer, and function-to-pointer conversion.
+     syntax UType ::= rvalType(Type) [function]
+
 endmodule

--- a/semantics/c/language/common/typing/misc.k
+++ b/semantics/c/language/common/typing/misc.k
@@ -629,4 +629,10 @@ module C-TYPING-MISC
           orBool isNonPaddingOffset(Offset, Decls, Types, Offsets)
      rule isNonPaddingOffset(_, .List, _, _) => false
 
+     rule rvalType(t(... st: _:SimpleArrayType) #as T::Type)
+          => utype(arrayToPtrType(T))
+     rule rvalType(t(... st: functionType(...)) #as T::Type)
+          => utype(pointerType(T))
+     rule rvalType(T::Type) => utype(T) [owise]
+
 endmodule

--- a/semantics/c/language/execution/expr/conditional.k
+++ b/semantics/c/language/execution/expr/conditional.k
@@ -30,9 +30,9 @@ module C-EXPR-CONDITIONAL
           [structural]
 
      rule (types(
-               t(Qs::Quals, Mods::Set, pointerType(T::Type)),
-               t(Qs'::Quals, Mods'::Set, pointerType(T'::Type))
-          ) => convertedType(t(Qs +Quals Qs', Mods Mods', pointerType(compositeType(T, T')))))
+               t(_, Mods::Set, pointerType(T::Type)),
+               t(_, Mods'::Set, pointerType(T'::Type))
+          ) => convertedType(t(noQuals, Mods Mods', pointerType(compositeType(T, T')))))
           ~> _? _ : _
           requires stripQualifiers(T) ==Type stripQualifiers(T')
           [structural]
@@ -42,10 +42,10 @@ module C-EXPR-CONDITIONAL
           [structural]
 
      syntax KItem ::= convertedType(Type)
-     rule convertedType(T:Type) ~> tv(1, ut(_, int)) ? E1:K : _
+     rule convertedType(T::Type) ~> tv(1, ut(_, int)) ? E1:K : _
           => sequencePoint ~> Cast(T, E1)
           [structural]
-     rule convertedType(T:Type) ~> tv(0, ut(_, int)) ? _ : E2:K
+     rule convertedType(T::Type) ~> tv(0, ut(_, int)) ? _ : E2:K
           => sequencePoint ~> Cast(T, E2)
           [structural]
      rule convertedType(_) ~> tv((unknown(I:Int) => #if I ==Int 0 #then 0 #else 1 #fi), ut(_, int)) ? _ : _

--- a/semantics/c/language/translation/expr/eval.k
+++ b/semantics/c/language/translation/expr/eval.k
@@ -4,10 +4,7 @@ module C-EXPR-EVAL
      imports C-DYNAMIC-SYNTAX
      imports C-TYPING-SYNTAX
 
-     rule reval(ncle(K:K, T::Type) => te(K, utype(T)))
-          requires notBool isArrayOrFunctionType(T)
-     rule reval(ncle(K:K, t(... st: _:SimpleArrayType) #as T::Type) => te(K, utype(arrayToPtrType(T))))
-     rule reval(ncle(K:K, t(... st: functionType(...)) #as T::Type) => te(K, utype(pointerType(T))))
+     rule reval(ncle(K:K, T::Type) => te(K, rvalType(T)))
 
      rule le(K:K, T::Type) => ncle(K, T)
 

--- a/semantics/c/language/translation/expr/generic.k
+++ b/semantics/c/language/translation/expr/generic.k
@@ -7,9 +7,11 @@ module C-EXPR-GENERIC
      imports C-TYPING-EXPR-SYNTAX
      imports C-TYPING-SYNTAX
 
-     rule (.K => typeof(E)) ~> Generic(E:K, _)
+     context Generic(HOLE:KItem => reval(HOLE), _)
+     rule (.K => typeof(E)) ~> Generic(E:RValue, _)
+
      rule typeof(T:Type) ~> Generic(_, list(Assocs::List))
-          => evalGeneric(T, Assocs, .List, .K)
+          => evalGeneric(type(rvalType(T)), Assocs, .List, .K)
 
      syntax KItem ::= evalGeneric(Type, List, List, K)
      rule (.K => DeclType(T', X))

--- a/semantics/c/language/translation/expr/members.k
+++ b/semantics/c/language/translation/expr/members.k
@@ -12,7 +12,7 @@ module C-EXPR-MEMBERS
           => le(K . F, addQualifiers(getQualifiers(T), findFieldType(F, T)))
           requires notBool (Atomic() inQuals getQualifiers(T))
 
-     rule te(K:K, structOrUnionUType #as T::UType) . F:CId => te(K . F, utype(findFieldType(F, type(T))))
+     rule te(K:K, structOrUnionUType #as T::UType) . F:CId => te(K . F, rvalType(findFieldType(F, type(T))))
 
      rule ncle(K::InitLValue, t(... st: _:SimpleArrayType) #as T::Type) [[ N::Int ]]
           => le(K [[ N ]], addQualifiers(getQualifiers(T), getElementType(N, T)))

--- a/semantics/c/language/translation/typing/expr.k
+++ b/semantics/c/language/translation/typing/expr.k
@@ -144,7 +144,7 @@ module C-TYPING-EXPR
      context typeof(Cast((HOLE:KItem), _, _)) [result(Type)]
      rule typeof(Cast(T:Type, K:K, V:K) => Cast(DeclType(T, K), V))
      context typeof(Cast(HOLE:KItem,_))
-     rule typeof(Cast(T:Type, _) => elideDeclParams(T))
+     rule typeof(Cast(T:Type, _) => elideDeclParams(type(rvalType(T))))
      rule typeof(cast(T:UType, _) => elideDeclParams(type(T)))
 
      syntax Type ::= usualArithmeticConversion(Type, Type) [klabel(usualArithmeticConversionQ), function]
@@ -203,17 +203,12 @@ module C-TYPING-EXPR
      context elaborateDone(_, _) ~> typeof(_ ? (HOLE:KItem => typeof(HOLE)) : _) [result(Type)]
      context elaborateDone(_, _) ~> typeof(_ ? _ : (HOLE:KItem => typeof(HOLE))) [result(Type)]
 
-     // fixme, not handling qualifiers correctly
-     syntax Type ::= retype(Type) [function]
-     rule retype(t(... st: _:SimpleArrayType) #as T::Type) => type(pointerType(innerType(T)))
-     rule retype(t(... st: functionType(...)) #as T::Type) => type(pointerType(T))
-
      syntax Bool ::= isNPC(K) [function]
      rule isNPC(V:RValue) => isNullPointerConstant(V)
      rule isNPC(_) => false [owise]
 
-     rule elaborateDone(_, _) ~> typeof(_ ? (arrayOrFunctionType #as T::Type => retype(T)) : _)
-     rule elaborateDone(_, _) ~> typeof(_ ? _ : (arrayOrFunctionType #as T::Type => retype(T)))
+     rule elaborateDone(_, _) ~> typeof(_ ? (arrayOrFunctionType #as T::Type => rvalType(T)) : _)
+     rule elaborateDone(_, _) ~> typeof(_ ? _ : (arrayOrFunctionType #as T::Type => rvalType(T)))
 
      /*@ \fromStandard{\source[n1570]{\para{6.5.15}{5}}}{
      If both the second and third operands have arithmetic type, the result
@@ -243,13 +238,14 @@ module C-TYPING-EXPR
      type is a pointer to an appropriately qualified version of
      \cinline{void}.
      }*/
-     rule (elaborateDone(_, _) ~> typeof(_ ? t(Qs::Quals, Mods::Set, pointerType(T::Type)) : t(Qs'::Quals, Mods'::Set, pointerType(T'::Type)))
-               => typeof(t(Qs +Quals Qs', Mods Mods', pointerType(compositeType(T, T')))))
+     // The result of the conditional is an rvalue, so it will be an unqualified type.
+     rule (elaborateDone(_, _) ~> typeof(_ ? t(_, Mods::Set, pointerType(T::Type)) : t(_, Mods'::Set, pointerType(T'::Type)))
+               => typeof(t(noQuals, Mods Mods', pointerType(compositeType(T, T')))))
           ~> SizeofExpression(_)
           requires stripQualifiers(T) ==Type stripQualifiers(T')
                andBool notBool (isSpecifiedVariablyModifiedType(T) orBool isSpecifiedVariablyModifiedType(T'))
-     rule (elaborateDone(_, _) ~> typeof(_ ? t(Qs::Quals, Mods::Set, pointerType(T::Type)) : t(Qs'::Quals, Mods'::Set, pointerType(T'::Type)))
-               => typeof(t(Qs +Quals Qs', Mods Mods', pointerType(compositeType(T, T')))))
+     rule (elaborateDone(_, _) ~> typeof(_ ? t(_, Mods::Set, pointerType(T::Type)) : t(_, Mods'::Set, pointerType(T'::Type)))
+               => typeof(t(noQuals, Mods Mods', pointerType(compositeType(T, T')))))
           ~> K:KItem
           requires stripQualifiers(T) ==Type stripQualifiers(T')
                andBool SizeofExpression(...) :/=K K
@@ -262,13 +258,13 @@ module C-TYPING-EXPR
           requires isNPC(V)
 
      rule elaborateDone(_, V:K)
-          ~> typeof(_ ? t(Qs1::Quals, Mods1::Set, pointerType(t(Qs1'::Quals, Mods1'::Set, T::SimpleType))) : t(Qs2::Quals, Mods2::Set, pointerType(t(Qs2'::Quals, Mods2'::Set, void))))
-          => typeof(t(Qs1 +Quals Qs2, Mods1 Mods2, pointerType(t(Qs1' +Quals Qs2', Mods1' Mods2', void))))
+          ~> typeof(_ ? t(_, Mods1::Set, pointerType(t(Qs1'::Quals, Mods1'::Set, T::SimpleType))) : t(_, Mods2::Set, pointerType(t(Qs2'::Quals, Mods2'::Set, void))))
+          => typeof(t(noQuals, Mods1 Mods2, pointerType(t(Qs1' +Quals Qs2', Mods1' Mods2', void))))
           requires notBool isFunctionType(type(T))
                andBool notBool isNPC(V)
      rule elaborateDone(V:K, _)
-          ~> typeof(_ ? t(Qs1::Quals, Mods1::Set, pointerType(t(Qs1'::Quals, Mods1'::Set, void))) : t(Qs2::Quals, Mods2::Set, pointerType(t(Qs2'::Quals, Mods2'::Set, T::SimpleType))))
-          => typeof(t(Qs1 +Quals Qs2, Mods1 Mods2, pointerType(t(Qs1' +Quals Qs2', Mods1' Mods2', void))))
+          ~> typeof(_ ? t(_, Mods1::Set, pointerType(t(Qs1'::Quals, Mods1'::Set, void))) : t(_, Mods2::Set, pointerType(t(Qs2'::Quals, Mods2'::Set, T::SimpleType))))
+          => typeof(t(noQuals, Mods1 Mods2, pointerType(t(Qs1' +Quals Qs2', Mods1' Mods2', void))))
           requires notBool isFunctionType(type(T))
                andBool notBool isNPC(V)
 

--- a/tests/unit-fail-compilation/generic-ref-rvalue.c
+++ b/tests/unit-fail-compilation/generic-ref-rvalue.c
@@ -1,0 +1,12 @@
+struct s { const int x; };
+
+struct s S;
+
+struct s f(void) {
+      return S;
+}
+
+
+int main() {
+      return _Generic(&(f().x), const int *: -1);
+}

--- a/tests/unit-fail-compilation/generic-ref-rvalue.c.ref
+++ b/tests/unit-fail-compilation/generic-ref-rvalue.c.ref
@@ -1,0 +1,8 @@
+generic-ref-rvalue.c:11:7: error: Unary '&' operator applied to non-lvalue.
+
+    Constraint violation (CV-CER1):
+        see C11 section 6.5.3.2:1 http://rvdoc.org/C11/6.5.3.2
+        see CERT-C section MSC40-C http://rvdoc.org/CERT-C/MSC40-C
+        see MISRA-C section 8.1:1 http://rvdoc.org/MISRA-C/8.1
+
+Translation failed (kcc_config dumped). To repeat, run this command in directory unit-fail-compilation:

--- a/tests/unit-pass/generic.c
+++ b/tests/unit-pass/generic.c
@@ -1,0 +1,16 @@
+extern void abort(void);
+
+// Based on excerpts from DR 423 and 481.
+int main() {
+      char const* a = _Generic("bla", char*: "blu");
+      // char const* b = _Generic("bla", char[4]: "blu");
+      char const* c = _Generic((int const){ 0 }, int: "blu");
+      // char const* d = _Generic((int const){ 0 }, int const: "blu");
+      char const* e = _Generic(+(int const){ 0 }, int: "blu");
+      // char const* f = _Generic(+(int const){ 0 }, int const: "blu");
+      char const* g = _Generic(abort, void(*)(void): "blu");
+      if (_Generic((double const) 0,
+                  default: 0,
+                  double const: 1))
+            abort();
+}


### PR DESCRIPTION
Fixes some issues raised by defect reports included in C18 related to the type of rvalue expressions (which can basically be observed now using `_Generic`).