### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 export K_BIN ?= $(ROOT)/.build/k/k-distribution/target/release/k/bin
 
 export K_OPTS := -Xmx8g -Xss32m
-export KOMPILE = $(K_BIN)/kompile -O2
-export KDEP = $(K_BIN)/kdep
+export KOMPILE := $(K_BIN)/kompile -O2
+export KDEP := $(K_BIN)/kdep
 
 export PROFILE_DIR := $(ROOT)/profiles/x86-gcc-limited-libc
 export PROFILE := $(shell basename $(PROFILE_DIR))
@@ -12,10 +12,11 @@ export SUBPROFILE_DIRS :=
 
 KCCFLAGS := -D_POSIX_C_SOURCE=200809 -nodefaultlibs -fno-native-compilation
 CFLAGS := -std=gnu11 -Wall -Wextra -Werror -pedantic
+CXXFLAGS := -std=c++17
 
 K_DIST := $(realpath $(K_BIN)/..)
 
-FILES_TO_DIST = \
+FILES_TO_DIST := \
 	scripts/kcc \
 	scripts/k++ \
 	scripts/kranlib \
@@ -36,35 +37,37 @@ FILES_TO_DIST = \
 	LICENSE \
 	licenses
 
-PROFILE_FILES = include src compiler-src native pp cpp-pp cc cxx
-PROFILE_FILE_DEPS = $(foreach f, $(PROFILE_FILES), $(PROFILE_DIR)/$(f))
-SUBPROFILE_FILE_DEPS = $(foreach d, $(SUBPROFILE_DIRS), $(foreach f, $(PROFILE_FILES), $(d)/$(f)))
-CC=$(PROFILE_DIR)/cc
+PROFILE_FILES := include src compiler-src native pp cpp-pp cc cxx
+PROFILE_FILE_DEPS := $(foreach f, $(PROFILE_FILES), $(PROFILE_DIR)/$(f))
+SUBPROFILE_FILE_DEPS := $(foreach d, $(SUBPROFILE_DIRS), $(foreach f, $(PROFILE_FILES), $(d)/$(f)))
+CC := $(PROFILE_DIR)/cc
 
-PERL_MODULES = \
+PERL_MODULES := \
 	scripts/RV_Kcc/Opts.pm \
 	scripts/RV_Kcc/Files.pm \
 	scripts/RV_Kcc/Shell.pm
 
-LIBC_SO = dist/profiles/$(PROFILE)/lib/libc.so
-LIBSTDCXX_SO = dist/profiles/$(PROFILE)/lib/libstdc++.so
+LIBC_SO := dist/profiles/$(PROFILE)/lib/libc.so
+LIBSTDCXX_SO := dist/profiles/$(PROFILE)/lib/libstdc++.so
 
 define timestamp_of
     dist/profiles/$(PROFILE)/$(1)-kompiled/$(1)-kompiled/timestamp
 endef
 
-.PHONY: default check-vars semantics clean stdlibs c-cpp-semantics test-build pass fail fail-compile parser/cparser clang-tools/clang-kast $(PROFILE)-native
-
+.PHONY: default
 default: test-build
 
-check-vars: check-ocaml check-cc check-perl check-k
+.PHONY: check-deps
+check-deps: | check-ocaml check-cc check-perl check-k
 
+.PHONY: check-ocaml
 check-ocaml:
 	@ocaml -version > /dev/null 2>&1 || { \
 		echo "ERROR: Missing OCaml installation. Please see INSTALL.md for more information." \
 		&& false; \
 	}
 
+.PHONY: check-cc
 check-cc:
 	@$(CC) -v > /dev/null 2>&1 || \
 		clang -v > /dev/null 2>&1 || { \
@@ -72,13 +75,15 @@ check-cc:
 			&& false; \
 		}
 
+.PHONY: check-perl
 check-perl:
 	@perl scripts/checkForModules.pl
 
 
+.PHONY: check-k
 check-k:
 	@$(K_BIN)/kompile --version > /dev/null 2>&1 || { \
-		echo "ERROR: Missing K installation. Please see Install.md for more information." \
+		echo "ERROR: Missing K installation. Please see INSTALL.md for more information." \
 		&& false; \
 	}
 
@@ -89,7 +94,7 @@ dist/writelong: scripts/writelong.c
 dist/extract-references: scripts/extract-references.cpp
 	@mkdir -p dist
 	@echo Building $@
-	@$(CXX) -std=c++17 $< -lstdc++fs -o $@
+	@$(CXX) $(CXXFLAGS) $< -lstdc++fs -o $@
 
 dist/kcc: scripts/getopt.pl $(PERL_MODULES) dist/writelong $(FILES_TO_DIST)
 	mkdir -p dist/RV_Kcc
@@ -112,7 +117,7 @@ pack: dist/kcc
 	cp -pf dist/kcc dist/kclang
 	rm -rf dist/fatlib dist/RV_Kcc dist/packlists dist/fatpacker.trace
 
-dist/profiles/$(PROFILE): dist/kcc $(PROFILE_FILE_DEPS) $(SUBPROFILE_FILE_DEPS) $(PROFILE)-native | check-vars
+dist/profiles/$(PROFILE): dist/kcc $(PROFILE_FILE_DEPS) $(SUBPROFILE_FILE_DEPS) $(PROFILE)-native | check-deps
 	@mkdir -p dist/profiles/$(PROFILE)/lib
 	@printf "%s" $(PROFILE) > dist/current-profile
 	@printf "%s" $(PROFILE) > dist/default-profile
@@ -125,67 +130,106 @@ dist/profiles/$(PROFILE): dist/kcc $(PROFILE_FILE_DEPS) $(SUBPROFILE_FILE_DEPS) 
 	@-$(foreach d, $(SUBPROFILE_DIRS), \
 		cp -RLp dist/profiles/$(PROFILE)/native/* dist/profiles/$(shell basename $(d))/native;)
 
+
 .SECONDEXPANSION:
 $(XYZ_SEMANTICS): %-semantics: $(call timestamp_of,$$*)
 # the % sign matches to '$(NAME)-kompiled/$(NAME)',
 # e.g. to 'c-cpp-kompiled/c-cpp'
-#dist/profiles/$(PROFILE)/c-cpp-kompiled/c-cpp-kompiled/timestamp
-dist/profiles/$(PROFILE)/%-kompiled/timestamp: dist/profiles/$(PROFILE) $$(notdir $$*)-semantics
+# dist/profiles/$(PROFILE)/c-cpp-kompiled/c-cpp-kompiled/timestamp
+dist/profiles/$(PROFILE)/%-kompiled/timestamp: dist/profiles/$(PROFILE) \
+                                               $$(notdir $$*)-semantics
 	$(eval NAME := $(notdir $*))
 	@echo "Distributing $(NAME)"
 	@cp -p -RL semantics/.build/$(PROFILE)/$(NAME)-kompiled dist/profiles/$(PROFILE)
 	@$(foreach d,$(SUBPROFILE_DIRS), \
 		cp -RLp semantics/.build/$(PROFILE)/$(NAME)-kompiled dist/profiles/$(shell basename $(d));)
 
-$(LIBSTDCXX_SO): $(call timestamp_of,c-cpp-linking) $(call timestamp_of,cpp-translation) $(wildcard $(PROFILE_DIR)/compiler-src/*.C) $(foreach d,$(SUBPROFILE_DIRS),$(wildcard $(d)/compiler-src/*)) dist/profiles/$(PROFILE)
+
+$(LIBSTDCXX_SO): $(call timestamp_of,c-cpp-linking) \
+                 $(call timestamp_of,cpp-translation) \
+                 $(wildcard $(PROFILE_DIR)/compiler-src/*.C) \
+                 $(foreach d,$(SUBPROFILE_DIRS),$(wildcard $(d)/compiler-src/*)) \
+                 dist/profiles/$(PROFILE)
 	@echo "$(PROFILE): Translating the C++ standard library..."
-	@cd $(PROFILE_DIR)/compiler-src && $(shell pwd)/dist/kcc --use-profile $(PROFILE) -shared -o $(shell pwd)/$@ *.C $(KCCFLAGS) -I .
+	@cd $(PROFILE_DIR)/compiler-src && \
+		$(ROOT)/dist/kcc --use-profile $(PROFILE) \
+				-shared -o $(ROOT)/$@ *.C \
+				$(KCCFLAGS) -I .
 	@$(foreach d,$(SUBPROFILE_DIRS), \
 		cd $(d)/compiler-src && \
-		$(shell pwd)/dist/kcc --use-profile $(shell basename $(d)) -shared -o $(shell pwd)/dist/profiles/$(shell basename $(d))/lib/libstdc++.so *.C $(KCCFLAGS) -I .;)
+			$(ROOT)/dist/kcc --use-profile $(shell basename $(d)) \
+				-shared -o $(ROOT)/dist/profiles/$(shell basename $(d))/lib/libstdc++.so \
+				*.C $(KCCFLAGS) -I .;)
 	@echo "$(PROFILE): Done translating the C++ standard library."
 
-$(LIBC_SO): $(call timestamp_of,c-cpp-linking) $(call timestamp_of,c-translation) $(wildcard $(PROFILE_DIR)/src/*.c) $(foreach d,$(SUBPROFILE_DIRS),$(wildcard $(d)/src/*.c)) dist/profiles/$(PROFILE)
+
+$(LIBC_SO): $(call timestamp_of,c-cpp-linking) \
+	          $(call timestamp_of,c-translation) \
+	          $(wildcard $(PROFILE_DIR)/src/*.c) \
+	          $(foreach d,$(SUBPROFILE_DIRS),$(wildcard $(d)/src/*.c)) \
+            dist/profiles/$(PROFILE)
 	@echo "$(PROFILE): Translating the C standard library..."
-	@cd $(PROFILE_DIR)/src && $(shell pwd)/dist/kcc --use-profile $(PROFILE) -shared -o $(shell pwd)/$@ *.c $(KCCFLAGS) -I .
+	@cd $(PROFILE_DIR)/src && \
+		$(ROOT)/dist/kcc --use-profile $(PROFILE) -shared -o $(ROOT)/$@ *.c $(KCCFLAGS) -I .
 	@$(foreach d,$(SUBPROFILE_DIRS), \
-		cd $(d)/src && $(shell pwd)/dist/kcc --use-profile $(shell basename $(d)) -shared -o $(shell pwd)/dist/profiles/$(shell basename $(d))/lib/libc.so *.c $(KCCFLAGS) -I .)
+		cd $(d)/src && \
+			$(ROOT)/dist/kcc --use-profile $(shell basename $(d)) \
+				-shared -o $(ROOT)/dist/profiles/$(shell basename $(d))/lib/libc.so \
+				*.c $(KCCFLAGS) -I .)
 	@echo "$(PROFILE): Done translating the C standard library."
 
-$(PROFILE)-native: dist/profiles/$(PROFILE)/native/main.o dist/profiles/$(PROFILE)/native/server.c dist/profiles/$(PROFILE)/native/builtins.o dist/profiles/$(PROFILE)/native/platform.o dist/profiles/$(PROFILE)/native/platform.h dist/profiles/$(PROFILE)/native/server.h
+
+.PHONY: $(PROFILE)-native
+$(PROFILE)-native: dist/profiles/$(PROFILE)/native/main.o \
+                   dist/profiles/$(PROFILE)/native/server.c \
+                   dist/profiles/$(PROFILE)/native/builtins.o \
+                   dist/profiles/$(PROFILE)/native/platform.o \
+                   dist/profiles/$(PROFILE)/native/platform.h \
+                   dist/profiles/$(PROFILE)/native/server.h
+
 
 dist/profiles/$(PROFILE)/native/main.o: native-server/main.c native-server/server.h
 	mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@  -g
+
 dist/profiles/$(PROFILE)/native/%.h: native-server/%.h
 	mkdir -p $(dir $@)
 	cp -RLp $< $@
+
 dist/profiles/$(PROFILE)/native/server.c: native-server/server.c
 	mkdir -p $(dir $@)
 	cp -RLp $< $@
-dist/profiles/$(PROFILE)/native/%.o: $(PROFILE_DIR)/native/%.c $(wildcard native-server/*.h)
+
+dist/profiles/$(PROFILE)/native/%.o: $(PROFILE_DIR)/native/%.c \
+                                     $(wildcard native-server/*.h)
 	mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@ -I native-server
 
-stdlibs: $(LIBC_SO) $(LIBSTDCXX_SO) $(call timestamp_of,c-cpp)
 
-test-build: stdlibs
+.PHONY: test-build
+test-build: $(LIBC_SO) \
+            $(LIBSTDCXX_SO) \
+            $(call timestamp_of,c-cpp)
 	@echo "Testing kcc..."
-	printf "#include <stdio.h>\nint main(void) {printf(\"x\"); return 42;}\n" | dist/kcc --use-profile $(PROFILE) -x c - -o dist/testProgram.compiled
-	dist/testProgram.compiled 2> /dev/null > dist/testProgram.out; test $$? -eq 42
-	grep x dist/testProgram.out > /dev/null
+	printf "#include <stdio.h>\nint main(void) { printf(\"x\"); return 42; }" \
+		| dist/kcc --use-profile $(PROFILE) -x c - -o dist/testProgram.compiled
+	dist/testProgram.compiled 2> /dev/null > dist/testProgram.out; \
+		test $$? -eq 42
+	grep x dist/testProgram.out > /dev/null 2>&1
 	@echo "Done."
 	@echo "Cleaning up..."
 	@rm -f dist/testProgram.compiled
 	@rm -f dist/testProgram.out
 	@echo "Done."
 
+.PHONY: parser/cparser
 parser/cparser:
 	@echo "Building the C parser..."
 	@$(MAKE) -C parser
 
 clang-tools/call-sites: clang-tools/clang-kast
 
+.PHONY: clang-tools/clang-kast
 clang-tools/clang-kast: clang-tools/Makefile
 	@echo "Building the C++ parser..."
 	@$(MAKE) -C clang-tools
@@ -209,23 +253,29 @@ execution-semantics: c-cpp-semantics
 
 XYZ_SEMANTICS := $(addsuffix -semantics,c-translation cpp-translation c-cpp-linking c-cpp)
 .PHONY: $(XYZ_SEMANTICS)
-$(XYZ_SEMANTICS): check-vars
+$(XYZ_SEMANTICS): | check-deps
 	@$(MAKE) -C semantics $@
 
-semantics: check-vars
+.PHONY: semantics
+semantics: | check-deps
 	@$(MAKE) -C semantics all
 
-check:	pass fail fail-compile
+.PHONY: check
+check: | pass fail fail-compile
 
-pass:	test-build
+.PHONY: pass
+pass:	| test-build
 	@$(MAKE) -C tests/unit-pass comparison
 
-fail:	test-build
+.PHONY: fail
+fail:	| test-build
 	@$(MAKE) -C tests/unit-fail comparison
 
-fail-compile:	test-build
+.PHONY: fail-compile
+fail-compile:	| test-build
 	@$(MAKE) -C tests/unit-fail-compilation comparison
 
+.PHONY: clean
 clean:
 	-$(MAKE) -C parser clean
 	-$(MAKE) -C clang-tools clean
@@ -234,5 +284,7 @@ clean:
 	-$(MAKE) -C tests/unit-pass clean
 	-$(MAKE) -C tests/unit-fail clean
 	-$(MAKE) -C tests/unit-fail-compilation clean
-	-rm -rf dist
-	-rm -f ./*.tmp ./*.log ./*.cil ./*-gen.maude ./*.gen.maude ./*.pre.gen ./*.prepre.gen ./a.out ./*.kdump ./*.pre.pre 
+	-rm -rf dist \
+					./*.tmp ./*.log ./*.cil ./*-gen.maude \
+					./*.gen.maude ./*.pre.gen ./*.prepre.gen \
+					./a.out ./*.kdump ./*.pre.pre 

--- a/semantics/Makefile
+++ b/semantics/Makefile
@@ -1,6 +1,11 @@
 KOMPILE_DEFAULT_FLAGS := --backend ocaml --non-strict --smt none
 CPP_KOMPILE_FLAGS := --opaque-klabels c-translation.k
-EXECUTION_KOMPILE_FLAGS := --opaque-klabels cpp-translation.k --no-expand-macros --ocaml-serialize-config '$$PGM' --ocaml-dump-exit-code 139
+EXECUTION_KOMPILE_FLAGS := \
+	--opaque-klabels \
+	cpp-translation.k \
+	--no-expand-macros \
+	--ocaml-serialize-config '$$PGM' \
+	--ocaml-dump-exit-code 139
 KDEP_DEFAULT_FLAGS :=
 
 define timestamp_of
@@ -12,27 +17,47 @@ default: fast
 
 $(call timestamp_of,c-translation):
 	@echo "Kompiling the static C semantics..."
-	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) c-translation.k -d ".build/$(PROFILE)/c-translation-kompiled" --no-prelude -w all -v --debug -I $(PROFILE_DIR)/semantics
+	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) c-translation.k \
+		-d ".build/$(PROFILE)/c-translation-kompiled" \
+		--no-prelude -w all -v --debug \
+		-I $(PROFILE_DIR)/semantics
 
 $(call timestamp_of,cpp-translation):
 	@echo "Kompiling the static C++ semantics..."
-	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(CPP_KOMPILE_FLAGS) cpp-translation.k -d ".build/$(PROFILE)/cpp-translation-kompiled" --no-prelude -w all -v --debug -I $(PROFILE_DIR)/semantics
+	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(CPP_KOMPILE_FLAGS) cpp-translation.k \
+		-d ".build/$(PROFILE)/cpp-translation-kompiled" \
+		--no-prelude -w all -v --debug \
+		-I $(PROFILE_DIR)/semantics
 
 $(call timestamp_of,c-cpp-linking):
 	@echo "Kompiling the C and C++ linking semantics..."
-	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(CPP_KOMPILE_FLAGS) c-cpp-linking.k -d ".build/$(PROFILE)/c-cpp-linking-kompiled" --no-prelude -w all -v --debug -I $(PROFILE_DIR)/semantics
+	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(CPP_KOMPILE_FLAGS) c-cpp-linking.k \
+		-d ".build/$(PROFILE)/c-cpp-linking-kompiled" \
+		--no-prelude -w all -v --debug \
+		-I $(PROFILE_DIR)/semantics
 
 $(call timestamp_of,c-cpp):
 	@echo "Kompiling the dynamic C and C++ semantics..."
-	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(EXECUTION_KOMPILE_FLAGS) c-cpp.k -d ".build/$(PROFILE)/c-cpp-kompiled" --no-prelude -w all -v --transition "interpRule" --debug -I $(PROFILE_DIR)/semantics
+	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(EXECUTION_KOMPILE_FLAGS) c-cpp.k \
+		-d ".build/$(PROFILE)/c-cpp-kompiled" \
+		--no-prelude -w all -v --transition "interpRule" \
+		--debug \
+		-I $(PROFILE_DIR)/semantics
 
 $(call timestamp_of,c-nd):
 	@echo "Kompiling the dynamic C and C++ semantics with expression sequencing non-determinism..."
-	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(EXECUTION_KOMPILE_FLAGS) c-cpp.k -d ".build/$(PROFILE)/c-nd-kompiled" --no-prelude --transition "observable ndtrans" --superheat "ndheat" --supercool "ndlocal" -I $(PROFILE_DIR)/semantics
+	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(EXECUTION_KOMPILE_FLAGS) c-cpp.k \
+		-d ".build/$(PROFILE)/c-nd-kompiled" \
+		--no-prelude --transition "observable ndtrans" \
+		--superheat "ndheat" --supercool "ndlocal" \
+		-I $(PROFILE_DIR)/semantics
 
 $(call timestamp_of,c-nd-thread):
 	@echo "Kompiling the dynamic C and C++ semantics with thread-interleaving non-determinism..."
-	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(EXECUTION_KOMPILE_FLAGS) c-cpp.k -d ".build/$(PROFILE)/c-nd-thread-kompiled" --no-prelude --transition "observable ndtrans ndthread" -I $(PROFILE_DIR)/semantics
+	$(KOMPILE) $(KOMPILE_DEFAULT_FLAGS) $(EXECUTION_KOMPILE_FLAGS) c-cpp.k \
+		-d ".build/$(PROFILE)/c-nd-thread-kompiled" \
+		--no-prelude --transition "observable ndtrans ndthread" \
+		-I $(PROFILE_DIR)/semantics
 
 .PHONY: all
 all: fast nd thread
@@ -56,9 +81,14 @@ thread: $(call timestamp_of,c-nd-thread)
 
 .PHONY: clean
 clean:
-	@-rm -rf */c-translation-kompiled */cpp-translation-kompiled */c-cpp-kompiled */c-nd-kompiled */c-nd-thread-kompiled .kompile-*
-	@-rm -rf .kompile-*
-	@-rm -rf .depend-* .build/*
+	@-rm -rf */c-translation-kompiled \
+           */cpp-translation-kompiled \
+					 */c-cpp-kompiled \
+					 */c-nd-kompiled \
+					 */c-nd-thread-kompiled \
+					 .kompile-* \
+					 .depend-* \
+					 .build/*
 
 BASIC_DEPENDS := $(addprefix .depend-$(PROFILE)-basic-,c-translation cpp-translation c-cpp-linking c-cpp)
 SPECIAL_DEPENDS := .depend-$(PROFILE)-nd .depend-$(PROFILE)-nd-thread
@@ -90,4 +120,3 @@ $(BASIC_DEPENDS): .depend-$(PROFILE)-basic-%:
 	$(eval TMP := $(shell mktemp))
 	$(KDEP) $(KDEP_FLAGS) -d ".build/$(PROFILE)/c-nd-thread-kompiled" -- c-cpp.k > $(TMP)
 	mv $(TMP) $@
-


### PR DESCRIPTION
Makefile improvements
 
* Better variable expansion
* Better path computations
* Done away with `$(shell pwd)`
* Code alignment
* `.PHONY` targets
* Order-only prerequisites

modified: `Makefile` and `semantics/Makefile`