### PR TITLE
clang-tools build refactoring

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     stage('Build') {
       steps {
         sh '''
-          eval $(opam config env)
+          eval "$(opam config env)"
           make -j4
         '''
       }
@@ -30,7 +30,7 @@ pipeline {
     stage('Test') {
       steps {
         sh '''
-          eval $(opam config env)
+          eval "$(opam config env)"
           make -C tests/unit-pass -j$(nproc) os-comparison
         '''
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     stage('Build') {
       steps {
         sh '''
-          eval "$(opam config env)"
+          eval $(opam config env)
           make -j4
         '''
       }
@@ -30,7 +30,7 @@ pipeline {
     stage('Test') {
       steps {
         sh '''
-          eval "$(opam config env)"
+          eval $(opam config env)
           make -C tests/unit-pass -j$(nproc) os-comparison
         '''
       }

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ CXXFLAGS := -std=c++17
 
 K_DIST := $(realpath $(K_BIN)/..)
 
+CLANG_TOOLS_BUILD_DIR := clang-tools/build
+CLANG_TOOLS_BIN := $(CLANG_TOOLS_BUILD_DIR)/bin
+
 FILES_TO_DIST := \
 	scripts/kcc \
 	scripts/k++ \
@@ -30,8 +33,8 @@ FILES_TO_DIST := \
 	scripts/program-runner \
 	scripts/histogram-csv \
 	parser/cparser \
-	clang-tools/clang-kast \
-	clang-tools/call-sites \
+	$(CLANG_TOOLS_BIN)/clang-kast \
+	$(CLANG_TOOLS_BIN)/call-sites \
 	scripts/cdecl-3.6/src/cdecl \
 	$(K_DIST) \
 	LICENSE \
@@ -227,15 +230,12 @@ parser/cparser:
 	@echo "Building the C parser..."
 	@$(MAKE) -C parser
 
-clang-tools/call-sites: clang-tools/clang-kast
+$(CLANG_TOOLS_BIN)/%: $(CLANG_TOOLS_BUILD_DIR)/Makefile
+	@$(MAKE) -C $(CLANG_TOOLS_BUILD_DIR) $*
 
-.PHONY: clang-tools/clang-kast
-clang-tools/clang-kast: clang-tools/Makefile
-	@echo "Building the C++ parser..."
-	@$(MAKE) -C clang-tools
-
-clang-tools/Makefile:
-	@cd clang-tools && cmake .
+$(CLANG_TOOLS_BUILD_DIR)/Makefile:
+	@mkdir -p $(CLANG_TOOLS_BUILD_DIR)
+	@cd $(CLANG_TOOLS_BUILD_DIR) && cmake ..
 
 scripts/cdecl-%/src/cdecl: scripts/cdecl-%.tar.gz
 	flock -w 120 $< sh -c 'cd scripts && tar xvf cdecl-$*.tar.gz && cd cdecl-$* && ./configure --without-readline && $(MAKE)' || true

--- a/Makefile
+++ b/Makefile
@@ -233,9 +233,10 @@ parser/cparser:
 $(CLANG_TOOLS_BIN)/%: $(CLANG_TOOLS_BUILD_DIR)/Makefile
 	@$(MAKE) -C $(CLANG_TOOLS_BUILD_DIR) $*
 
-$(CLANG_TOOLS_BUILD_DIR)/Makefile:
+$(CLANG_TOOLS_BUILD_DIR)/Makefile: clang-tools/CMakeLists.txt
 	@mkdir -p $(CLANG_TOOLS_BUILD_DIR)
-	@cd $(CLANG_TOOLS_BUILD_DIR) && cmake ..
+	@cd $(CLANG_TOOLS_BUILD_DIR) \
+		&& test -f Makefile || cmake ..
 
 scripts/cdecl-%/src/cdecl: scripts/cdecl-%.tar.gz
 	flock -w 120 $< sh -c 'cd scripts && tar xvf cdecl-$*.tar.gz && cd cdecl-$* && ./configure --without-readline && $(MAKE)' || true

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ fail-compile:	| test-build
 .PHONY: clean
 clean:
 	-$(MAKE) -C parser clean
-	-$(MAKE) -C clang-tools clean
+	-rm -rf $(CLANG_TOOLS_BUILD_DIR)
 	-$(MAKE) -C semantics clean
 	-$(MAKE) -C tests clean
 	-$(MAKE) -C tests/unit-pass clean

--- a/clang-tools/.gitignore
+++ b/clang-tools/.gitignore
@@ -1,7 +1,1 @@
-CMakeCache.txt
-CMakeFiles
-Makefile
-cmake_install.cmake
-clang-kast
-call-sites
-
+build/

--- a/clang-tools/CMakeLists.txt
+++ b/clang-tools/CMakeLists.txt
@@ -1,23 +1,42 @@
-cmake_minimum_required(VERSION 2.8.4)
-project(clang-tools)
+cmake_minimum_required ( VERSION 3.10.2 )
 
-set(LLVM_PATH /usr/lib/llvm-6.0 CACHE PATH "LLVM path")
-link_directories(${LLVM_PATH}/lib)
-include_directories(${LLVM_PATH}/include)
+project ( clang-tools LANGUAGES CXX )
 
-add_definitions(
--D__STDC_LIMIT_MACROS
--D__STDC_CONSTANT_MACROS
+
+find_package ( Curses REQUIRED )
+find_package ( LLVM 6.0 EXACT REQUIRED CONFIG )
+
+link_directories ( ${LLVM_LIBRARY_DIRS} )
+link_directories ( ${CURSES_LIBRARY_DIRS} )
+
+include_directories ( ${LLVM_INCLUDE_DIRS} )
+include_directories ( ${CURSES_INCLUDE_DIRS} )
+
+add_compile_options (
+  -Wall
+  -Wno-unused-variable
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-unused-variable")
-set(CLANG_KAST_FILES ClangKast.cc)
-set(CALL_SITES_FILES CallSites.cc)
-add_executable(clang-kast ${CLANG_KAST_FILES})
-add_executable(call-sites ${CALL_SITES_FILES})
+add_executable(clang-kast ClangKast.cc)
+add_executable(call-sites CallSites.cc)
 
-include(FindCurses)
-set(LIBS
+set_target_properties (
+  clang-kast
+  call-sites
+  PROPERTIES
+    CXX_STANDARD 11
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD_REQUIRED ON 
+)
+
+add_definitions (
+  -D__STDC_LIMIT_MACROS
+  -D__STDC_CONSTANT_MACROS
+)
+
+
+# NOTE: find_package(LLVM...) does not populate this variable, unfortunately.
+set ( LLVM_LIBRARIES
   clangFrontend
   clangSerialization
   clangDriver
@@ -49,14 +68,14 @@ set(LIBS
   LLVMCore # Support
   LLVMBinaryFormat
   LLVMSupport
-  pthread
-  z
-  dl
-  ${CURSES_LIBRARIES}
 )
 
-target_link_libraries(clang-kast ${LIBS})
-target_link_libraries(call-sites ${LIBS})
+
+target_link_libraries ( clang-kast PRIVATE ${LLVM_LIBRARIES} )
+target_link_libraries ( call-sites PRIVATE ${LLVM_LIBRARIES} )
+
+target_link_libraries ( clang-kast PRIVATE ${CURSES_LIBRARIES} )
+target_link_libraries ( call-sites PRIVATE ${CURSES_LIBRARIES} )
 
 install(TARGETS clang-kast
         RUNTIME DESTINATION bin)

--- a/clang-tools/CMakeLists.txt
+++ b/clang-tools/CMakeLists.txt
@@ -6,8 +6,6 @@ project ( clang-tools LANGUAGES CXX )
 find_package ( Curses REQUIRED )
 find_package ( LLVM 6.0 EXACT REQUIRED CONFIG )
 
-message ( STATUS "${CURSES_LIBRARIES}" )
-
 link_directories ( ${LLVM_LIBRARY_DIRS} )
 
 # NOTE: not needed because CURSES_LIBRARIES contains full paths.

--- a/clang-tools/CMakeLists.txt
+++ b/clang-tools/CMakeLists.txt
@@ -27,6 +27,7 @@ set_target_properties (
     CXX_STANDARD 11
     CXX_EXTENSIONS OFF
     CXX_STANDARD_REQUIRED ON 
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
 add_definitions (
@@ -76,8 +77,3 @@ target_link_libraries ( call-sites PRIVATE ${LLVM_LIBRARIES} )
 
 target_link_libraries ( clang-kast PRIVATE ${CURSES_LIBRARIES} )
 target_link_libraries ( call-sites PRIVATE ${CURSES_LIBRARIES} )
-
-install(TARGETS clang-kast
-        RUNTIME DESTINATION bin)
-install(TARGETS call-sites
-        RUNTIME DESTINATION bin)

--- a/clang-tools/CMakeLists.txt
+++ b/clang-tools/CMakeLists.txt
@@ -6,8 +6,12 @@ project ( clang-tools LANGUAGES CXX )
 find_package ( Curses REQUIRED )
 find_package ( LLVM 6.0 EXACT REQUIRED CONFIG )
 
+message ( STATUS "${CURSES_LIBRARIES}" )
+
 link_directories ( ${LLVM_LIBRARY_DIRS} )
-link_directories ( ${CURSES_LIBRARY_DIRS} )
+
+# NOTE: not needed because CURSES_LIBRARIES contains full paths.
+# link_directories ( ${CURSES_LIBRARY_DIRS} )
 
 include_directories ( ${LLVM_INCLUDE_DIRS} )
 include_directories ( ${CURSES_INCLUDE_DIRS} )

--- a/clang-tools/CMakeLists.txt
+++ b/clang-tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 3.5.2 )
+cmake_minimum_required ( VERSION 3.5 )
 
 project ( clang-tools LANGUAGES CXX )
 

--- a/clang-tools/CMakeLists.txt
+++ b/clang-tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 3.5 )
+cmake_minimum_required ( VERSION 3.5.2 )
 
 project ( clang-tools LANGUAGES CXX )
 

--- a/clang-tools/CMakeLists.txt
+++ b/clang-tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 3.10.2 )
+cmake_minimum_required ( VERSION 3.5 )
 
 project ( clang-tools LANGUAGES CXX )
 

--- a/clang-tools/CallSites.cc
+++ b/clang-tools/CallSites.cc
@@ -1,4 +1,13 @@
 #define _XOPEN_SOURCE 700
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcomment"
+#elif defined __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcomment"
+#endif
+
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Mangle.h"
@@ -7,8 +16,15 @@
 #include "clang/Frontend/FrontendAction.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
-#include<cstdio>
-#include<string>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#elif defined __clang__
+#pragma clang diagnostic pop
+#endif
+
+#include <cstdio>
+#include <string>
 
 using namespace clang;
 using namespace clang::tooling;
@@ -43,7 +59,7 @@ public:
 
 
 #define TYPE(CLASS, BASE)                                                     \
-  bool WalkUpFrom##CLASS##Type(clang::CLASS##Type *T) {                              \
+  bool WalkUpFrom##CLASS##Type(clang::CLASS##Type *T) {                       \
     WALK_UP_HELPER(Visit##CLASS##Type(T));                                    \
     WALK_UP_HELPER(WalkUpFrom##BASE(T));                                      \
     return true;                                                              \

--- a/clang-tools/ClangKast.cc
+++ b/clang-tools/ClangKast.cc
@@ -1,4 +1,13 @@
 #define _XOPEN_SOURCE 700
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcomment"
+#elif defined __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcomment"
+#endif
+
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Mangle.h"
@@ -8,10 +17,19 @@
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/Support/CommandLine.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#elif defined __clang__
+#pragma clang diagnostic pop
+#endif
+
+
 #include <cstdio>
 #include <vector>
 #include <fcntl.h>
 #include <unistd.h>
+
 
 using namespace clang;
 using namespace clang::tooling;
@@ -2371,41 +2389,43 @@ public:
   bool VisitAtomicExpr(AtomicExpr *E) {
     AddKApplyNode("GnuAtomicExpr", 2);
     switch(E->getOp()) {
-    #define ATOMIC_BUILTIN(Name, Spelling)         \
-    case AtomicExpr::AO##Name:                                 \
-      AddKTokenNode("\"" Spelling "\"", "String"); \
-      break;
-    ATOMIC_BUILTIN(__c11_atomic_init, "__c11_atomic_init")
-    ATOMIC_BUILTIN(__c11_atomic_load, "__c11_atomic_load")
-    ATOMIC_BUILTIN(__c11_atomic_store, "__c11_atomic_store")
-    ATOMIC_BUILTIN(__c11_atomic_exchange, "__c11_atomic_exchange")
-    ATOMIC_BUILTIN(__c11_atomic_compare_exchange_strong, "__c11_atomic_compare_exchange_strong")
-    ATOMIC_BUILTIN(__c11_atomic_compare_exchange_weak, "__c11_atomic_compare_exchange_weak")
-    ATOMIC_BUILTIN(__c11_atomic_fetch_add, "__c11_atomic_fetch_add")
-    ATOMIC_BUILTIN(__c11_atomic_fetch_sub, "__c11_atomic_fetch_sub")
-    ATOMIC_BUILTIN(__c11_atomic_fetch_and, "__c11_atomic_fetch_and")
-    ATOMIC_BUILTIN(__c11_atomic_fetch_or, "__c11_atomic_fetch_or")
-    ATOMIC_BUILTIN(__c11_atomic_fetch_xor, "__c11_atomic_fetch_xor")
-    ATOMIC_BUILTIN(__atomic_load, "__atomic_load")
-    ATOMIC_BUILTIN(__atomic_load_n, "__atomic_load_n")
-    ATOMIC_BUILTIN(__atomic_store, "__atomic_store")
-    ATOMIC_BUILTIN(__atomic_store_n, "__atomic_store_n")
-    ATOMIC_BUILTIN(__atomic_exchange, "__atomic_exchange")
-    ATOMIC_BUILTIN(__atomic_exchange_n, "__atomic_exchange_n")
-    ATOMIC_BUILTIN(__atomic_compare_exchange, "__atomic_compare_exchange")
-    ATOMIC_BUILTIN(__atomic_compare_exchange_n, "__atomic_compare_exchange_n")
-    ATOMIC_BUILTIN(__atomic_fetch_add, "__atomic_fetch_add")
-    ATOMIC_BUILTIN(__atomic_fetch_sub, "__atomic_fetch_sub")
-    ATOMIC_BUILTIN(__atomic_fetch_and, "__atomic_fetch_and")
-    ATOMIC_BUILTIN(__atomic_fetch_or, "__atomic_fetch_or")
-    ATOMIC_BUILTIN(__atomic_fetch_xor, "__atomic_fetch_xor")
-    ATOMIC_BUILTIN(__atomic_fetch_nand, "__atomic_fetch_nand")
-    ATOMIC_BUILTIN(__atomic_add_fetch, "__atomic_add_fetch")
-    ATOMIC_BUILTIN(__atomic_sub_fetch, "__atomic_sub_fetch")
-    ATOMIC_BUILTIN(__atomic_and_fetch, "__atomic_and_fetch")
-    ATOMIC_BUILTIN(__atomic_or_fetch, "__atomic_or_fetch")
-    ATOMIC_BUILTIN(__atomic_xor_fetch, "__atomic_xor_fetch")
-    ATOMIC_BUILTIN(__atomic_nand_fetch, "__atomic_nand_fetch")
+			#define ATOMIC_BUILTIN(Name, Spelling)           \
+				case AtomicExpr::AO##Name:                     \
+					AddKTokenNode("\"" Spelling "\"", "String"); \
+					break;
+      ATOMIC_BUILTIN(__c11_atomic_init, "__c11_atomic_init")
+      ATOMIC_BUILTIN(__c11_atomic_load, "__c11_atomic_load")
+      ATOMIC_BUILTIN(__c11_atomic_store, "__c11_atomic_store")
+      ATOMIC_BUILTIN(__c11_atomic_exchange, "__c11_atomic_exchange")
+      ATOMIC_BUILTIN(__c11_atomic_compare_exchange_strong, "__c11_atomic_compare_exchange_strong")
+      ATOMIC_BUILTIN(__c11_atomic_compare_exchange_weak, "__c11_atomic_compare_exchange_weak")
+      ATOMIC_BUILTIN(__c11_atomic_fetch_add, "__c11_atomic_fetch_add")
+      ATOMIC_BUILTIN(__c11_atomic_fetch_sub, "__c11_atomic_fetch_sub")
+      ATOMIC_BUILTIN(__c11_atomic_fetch_and, "__c11_atomic_fetch_and")
+      ATOMIC_BUILTIN(__c11_atomic_fetch_or, "__c11_atomic_fetch_or")
+      ATOMIC_BUILTIN(__c11_atomic_fetch_xor, "__c11_atomic_fetch_xor")
+      ATOMIC_BUILTIN(__atomic_load, "__atomic_load")
+      ATOMIC_BUILTIN(__atomic_load_n, "__atomic_load_n")
+      ATOMIC_BUILTIN(__atomic_store, "__atomic_store")
+      ATOMIC_BUILTIN(__atomic_store_n, "__atomic_store_n")
+      ATOMIC_BUILTIN(__atomic_exchange, "__atomic_exchange")
+      ATOMIC_BUILTIN(__atomic_exchange_n, "__atomic_exchange_n")
+      ATOMIC_BUILTIN(__atomic_compare_exchange, "__atomic_compare_exchange")
+      ATOMIC_BUILTIN(__atomic_compare_exchange_n, "__atomic_compare_exchange_n")
+      ATOMIC_BUILTIN(__atomic_fetch_add, "__atomic_fetch_add")
+      ATOMIC_BUILTIN(__atomic_fetch_sub, "__atomic_fetch_sub")
+      ATOMIC_BUILTIN(__atomic_fetch_and, "__atomic_fetch_and")
+      ATOMIC_BUILTIN(__atomic_fetch_or, "__atomic_fetch_or")
+      ATOMIC_BUILTIN(__atomic_fetch_xor, "__atomic_fetch_xor")
+      ATOMIC_BUILTIN(__atomic_fetch_nand, "__atomic_fetch_nand")
+      ATOMIC_BUILTIN(__atomic_add_fetch, "__atomic_add_fetch")
+      ATOMIC_BUILTIN(__atomic_sub_fetch, "__atomic_sub_fetch")
+      ATOMIC_BUILTIN(__atomic_and_fetch, "__atomic_and_fetch")
+      ATOMIC_BUILTIN(__atomic_or_fetch, "__atomic_or_fetch")
+      ATOMIC_BUILTIN(__atomic_xor_fetch, "__atomic_xor_fetch")
+      ATOMIC_BUILTIN(__atomic_nand_fetch, "__atomic_nand_fetch")
+			#undef ATOMIC_BUILTIN
+      default: break;
     }
     AddKSequenceNode(E->getNumSubExprs());
     return false;
@@ -2414,6 +2434,7 @@ public:
   bool VisitPredefinedExpr(PredefinedExpr *E) {
     return false;
   }
+
 
   // the rest of these are not part of the syntax of C but we keep them and transform them later
   // in order to avoid having to deal with messy syntax transformations within the parser

--- a/clang-tools/ClangKast.cc
+++ b/clang-tools/ClangKast.cc
@@ -2389,10 +2389,10 @@ public:
   bool VisitAtomicExpr(AtomicExpr *E) {
     AddKApplyNode("GnuAtomicExpr", 2);
     switch(E->getOp()) {
-			#define ATOMIC_BUILTIN(Name, Spelling)           \
-				case AtomicExpr::AO##Name:                     \
-					AddKTokenNode("\"" Spelling "\"", "String"); \
-					break;
+      #define ATOMIC_BUILTIN(Name, Spelling)           \
+        case AtomicExpr::AO##Name:                     \
+          AddKTokenNode("\"" Spelling "\"", "String"); \
+          break;
       ATOMIC_BUILTIN(__c11_atomic_init, "__c11_atomic_init")
       ATOMIC_BUILTIN(__c11_atomic_load, "__c11_atomic_load")
       ATOMIC_BUILTIN(__c11_atomic_store, "__c11_atomic_store")
@@ -2424,8 +2424,7 @@ public:
       ATOMIC_BUILTIN(__atomic_or_fetch, "__atomic_or_fetch")
       ATOMIC_BUILTIN(__atomic_xor_fetch, "__atomic_xor_fetch")
       ATOMIC_BUILTIN(__atomic_nand_fetch, "__atomic_nand_fetch")
-			#undef ATOMIC_BUILTIN
-      default: break;
+      #undef ATOMIC_BUILTIN
     }
     AddKSequenceNode(E->getNumSubExprs());
     return false;


### PR DESCRIPTION
* Fixes https://github.com/kframework/c-semantics/issues/429
   - out-of-source build for `clang-tools`
   - `make clean` removes `clang-tools/build`
   -  Added `build/` to `clang-tools/.gitignore`

* Improved `clang-tools/CMakeLists.txt`.
  - Removed hard-coded library paths. Using
     `find_package` instead.
  - Modernized other code.
  - Changed minimum version to 3.5
  - Removed the installation targets
     - they are not maintained/used

* Removed some compiler warnings for `clang-tools/*.cc`.