### PR TITLE
remove TypeMap functionality from C semantics

### DIFF
--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -847,16 +847,16 @@ module CPP-DYNAMIC-OTHER
 
      rule showSignature(Q::QualId, t(_, _, functionType(... paramTypes: T::CPPTypes))) => showQualId(Q) +String "(" +String showCPPTypes(T) +String ")"
 
-     rule X:KItem, T:CPPType in_keys(M::Map) => (X in_keys(M)) andBool (T in_keys({M[X]}:>TypeMap))
+     rule X:KItem, T:CPPType in_keys(M::Map) => (X in_keys(M)) andBool (T in_keys({M[X]}:>Map))
 
      rule X:KItem, Y:KItem in_keys(M::Map) => (X in_keys(M)) andBool (Y in_keys({M[X] orDefault .Map}:>Map)) [owise]
 
-     rule ((A |-> M2:TypeMap) M1::Map) [A:KItem, B:CPPType <- C:KItem] => (A |-> (M2[B <- C])) M1
+     rule ((A |-> M2:Map) M1::Map) [A:KItem, B:CPPType <- C:KItem] => (A |-> (M2[stripType(B) <- (B, C)])) M1
 
      rule ((A |-> M2::Map) M1::Map) [A:KItem, B:KItem <- C:KItem] => (A |-> (M2[B <- C])) M1
           requires notBool isCPPType(B)
 
-     rule M::Map [A:KItem, B:CPPType <- C:KItem] => M A |-> (B |-> C) [owise]
+     rule M::Map [A:KItem, B:CPPType <- C:KItem] => M A |-> (stripType(B) |-> (B, C)) [owise]
 
      rule M::Map [A:KItem, B:KItem <- C:KItem] => M A |-> (B |-> C)::Map
           requires notBool isCPPType(B)

--- a/semantics/cpp/language/common/expr/members.k
+++ b/semantics/cpp/language/common/expr/members.k
@@ -31,7 +31,7 @@ module CPP-EXPR-MEMBERS
            => fieldExp(V, addQuals(getQuals(type(V)), T), Offset +Int PrevOffset)
           ...</k>
           <class-id> FC </class-id>
-          <cenv>... F |-> (T::CPPType |-> classOffset(_, Offset::Int)) ...</cenv>
+          <cenv>... F |-> (_ |-> (T::CPPType, classOffset(_, Offset::Int))) ...</cenv>
           requires type(simpleType(TC)) ==Type type(classType(FC))
 
      rule lookupFieldCPP(_::Val, t(... st: classType(DC::Class => BC)), Name(BC::Class, _), PrevOffset::Int => PrevOffset +Int getBaseClassOffset(BC, DC))
@@ -39,7 +39,7 @@ module CPP-EXPR-MEMBERS
 
      rule <k> lookupFieldCPP(_::Val, t(... st: classType(FC::Class => C)), Name(FC::Class => C, F::CId), PrevOffset::Int => PrevOffset +Int Offset) ...</k>
           <class-id> FC </class-id>
-          <cenv>... F |-> (_::CPPType |-> envEntry(... base: memberBase(unnamedObject(C::Class), _, _))) unnamedObject(C) |-> (_::CPPType |-> classOffset(_, Offset::Int)) ...</cenv>
+          <cenv>... F |-> (_::CPPType |-> (_, envEntry(... base: memberBase(unnamedObject(C::Class), _, _)))) unnamedObject(C) |-> (_::CPPType |-> (_, classOffset(_, Offset::Int))) ...</cenv>
 
      rule fieldExp(L::GLVal, T::CPPType, Offset::Int)
           => makeVal(cat(L), locOf(L) +bytes Offset /Int cfg:bitsPerByte, noTrace, T)

--- a/semantics/cpp/language/common/map.k
+++ b/semantics/cpp/language/common/map.k
@@ -1,46 +1,13 @@
-module CPP-TYPE-MAP-SORTS
-     syntax TypeMap [hook(MAP.Map)]
-endmodule
-
 module CPP-TYPE-MAP-SYNTAX
-     imports CPP-TYPE-MAP-SORTS
      imports CPP-TYPING-SORTS
      imports BASIC-K
+     imports MAP
 
-     syntax TypeMap ::= TypeMap TypeMap [left, function, hook(MAP.concat), klabel(_TypeMap_), assoc, comm, unit(.TypeMap), element(_|->TypeMap_), remove(_[_<-undef]_CPP-TYPE-MAP-SYNTAX), lookup(_[_]_CPP-TYPE-MAP-SYNTAX), choice(#filterMapChoice), filterElement(elemTypeMap)]
-
-     syntax TypeMap ::= ".Map" [function, hook(MAP.unit), klabel(.TypeMap), prefer]
-
-     syntax TypeMap ::= CPPType "|->" KItem [function, klabel(_|->TypeMap_), prefer]
-
-     syntax priorities _|->TypeMap_ > _TypeMap_ .TypeMap
-
-     syntax priorities _|->_ > _TypeMap_ .TypeMap
-
-     syntax non-assoc _|->TypeMap_
-
-     syntax KItem ::= TypeMap "[" CPPType "]" [function]
-
-     syntax KItem ::= TypeMap "[" CPPType "]" "orDefault" KItem [function]
-
-     syntax TypeMap ::= TypeMap "[" CPPType "<-" KItem "]" [function]
-
-     syntax TypeMap ::= TypeMap "[" CPPType "<-" "undef" "]" [function]
-
-     syntax TypeMap ::= updateMap(TypeMap, TypeMap) [function, klabel(updateAllTypeMap), hook(MAP.updateAll)]
-
-     syntax Map ::= Map "[" KItem "<+" TypeMap "]" [function]
-
-     syntax Bool ::= CPPType "in_keys" "(" TypeMap ")" [function]
-                   | some(TypeMap, TypePredicate) [function, klabel(someTypeMap)]
+     syntax Bool ::= some(Map, TypePredicate) [function, klabel(someTypeMap), prefer]
      syntax TypePredicate
      syntax Bool ::= TypePredicate "(" CPPType "," K ")" [function]
-
-     syntax List ::= "keys_list" "(" TypeMap ")" [function]
-
-     syntax Int ::= size(TypeMap) [function, hook(MAP.size), klabel(sizeTypeMap)]
-
-     syntax List ::= Map2List(TypeMap) [function]
+     syntax KItem ::= "(" CPPType "," KItem ")"
+     syntax List ::= Map2List(Map) [function]
 endmodule
 
 module CPP-TYPE-MAP
@@ -51,50 +18,11 @@ module CPP-TYPE-MAP
      imports LIST
      imports MAP
 
-     syntax TypeMap ::= elem(CPPType, KItem) [function, hook(MAP.element), klabel(elemTypeMap)]
+     rule some(.Map, _::TypePredicate) => false
 
-     syntax KItem ::= lookup(TypeMap, CPPType) [function, hook(MAP.lookup), klabel(lookupTypeMap)]
-
-     syntax KItem ::= lookupOrDefault(TypeMap, CPPType, KItem) [function, hook(MAP.lookupOrDefault), klabel(lookupOrDefaultTypeMap)]
-
-     syntax TypeMap ::= update(TypeMap, CPPType, KItem) [function, hook(MAP.update), klabel(updateTypeMap)]
-
-     syntax TypeMap ::= remove(TypeMap, CPPType) [function, hook(MAP.remove), klabel(removeTypeMap)]
-
-     syntax Bool ::= inKeys(CPPType, TypeMap) [function, hook(MAP.in_keys), klabel(in_keysTypeMap)]
-
-     syntax List ::= values(TypeMap) [function, hook(MAP.values), klabel(valuesTypeMap)]
-
-     rule T::CPPType |-> K:KItem => elem(stripType(T), kpair(T, K))
-
-     rule M::TypeMap [ T::CPPType ] => #selectValue(lookup(M, stripType(T)))
-
-     syntax KItem ::= #selectValue(KItem) [function]
-
-     rule #selectValue(kpair(_, K:KItem)) => K
-
-     rule #selectValue(K:KItem) => K [owise] // propagate Bottom
-
-     rule M::TypeMap [ T::CPPType ] orDefault D:KItem => #fun((kpair(_, K:KItem) => K))(lookupOrDefault(M, stripType(T), kpair(.K, D)))
-
-     rule M::TypeMap [ T::CPPType <- K:KItem ] => update(M, stripType(T), kpair(T, K))
-
-     rule M::TypeMap [ T::CPPType <- undef ] => remove(M, stripType(T))
-
-     rule T::CPPType in_keys(M::TypeMap) => inKeys(stripType(T), M)
-
-     rule some(.Map::TypeMap, _) => false
-
-     rule some(K1::CPPType |-> K2:KItem M::TypeMap, T::TypePredicate) => T(K1, K2) orBool some(M, T) [owise]
-
-     rule keys_list(T::CPPType |-> _:KItem M::TypeMap) => ListItem(T) keys_list(M)
-     rule keys_list(.Map::TypeMap) => .List
-
-     rule Map2List(K1::CPPType |-> K2:KItem M::TypeMap) => ListItem(kpair(K1, K2)) Map2List(M)
+     rule some(_::CPPType |-> (K1::CPPType, K2:KItem) M::Map, T::TypePredicate) => T(K1, K2) orBool some(M, T) [owise]
 
      rule Map2List(.Map) => .List
+     rule Map2List(_::CPPType |-> (T::CPPType, K:KItem) M::Map) => ListItem(kpair(T, K)) Map2List(M)
 
-     rule ((A |-> M2:TypeMap) M1::Map) [A:KItem <+ B:TypeMap] => (A |-> (M2 B)) M1
-
-     rule M::Map [A:KItem <+ B:TypeMap] => M A |-> B [owise]
 endmodule

--- a/semantics/cpp/language/common/typing.k
+++ b/semantics/cpp/language/common/typing.k
@@ -909,7 +909,7 @@ module CPP-TYPING
      rule #getDirectBaseClassOffsets(M::Map => M[B <- CurrentOffset +Int Offset],
                (ListItem(t(...st: classType(B::Class)) #as T::CPPType) => .List) _,
                CurrentOffset::Int,
-               (baseClass(B) |-> (_::TypeMap T |-> classOffset(_, Offset::Int))) _::Map)
+               (baseClass(B) |-> (_::Map stripType(T) |-> (_,classOffset(_, Offset::Int)))) _::Map)
      requires notBool (B in_keys(M))
 
 

--- a/semantics/cpp/language/execution/expr/function-call.k
+++ b/semantics/cpp/language/execution/expr/function-call.k
@@ -93,7 +93,7 @@ module CPP-EXECUTION-EXPR-FUNCTION-CALL
           <tu-id> Tu </tu-id>
           <class-id> Candidate </class-id>
           <base-classes> Bases::List </base-classes>
-          <cenv>... VF |-> M::TypeMap ...</cenv>
+          <cenv>... VF |-> M::Map ...</cenv>
           requires isBaseClassOf(C, Candidate) andBool getOverride(T, M) ==K type(no-type)::CPPType
 
      rule <k> getOverrides((C::Class => Candidate), VF::CId, (T::CPPType => getOverride(T, M)), (ListItem(Candidate::Class) => .List) _) ...</k>
@@ -101,18 +101,18 @@ module CPP-EXECUTION-EXPR-FUNCTION-CALL
           <tu-id> Tu </tu-id>
           <class-id> Candidate </class-id>
           <base-classes> Bases::List </base-classes>
-          <cenv>... VF |-> M::TypeMap ...</cenv>
+          <cenv>... VF |-> M::Map ...</cenv>
           requires isBaseClassOf(C, Candidate) andBool getOverride(T, M) =/=K type(no-type)::CPPType
 
      rule <k> getOverrides(C::Class, VF::CId, T::CPPType, .List) => lv(lnew(Base), noTrace, T) ...</k>
           <curr-tu> Tu::String </curr-tu>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <cenv>... VF |-> (_::TypeMap T::CPPType |-> envEntry(... base: Base::SymBase)) ...</cenv>
+          <cenv>... VF |-> (_::Map stripType(T::CPPType) |-> (_, envEntry(... base: Base::SymBase))) ...</cenv>
 
-     syntax CPPType ::= getOverride(CPPType, TypeMap) [function]
+     syntax CPPType ::= getOverride(CPPType, Map) [function]
 
-     rule getOverride(BaseClassFunc::CPPType, DerivedClassFunc::CPPType |-> envEntry(Base::SymBase, false, _) _)
+     rule getOverride(BaseClassFunc::CPPType, _::CPPType |-> (DerivedClassFunc::CPPType, envEntry(Base::SymBase, false, _)) _)
           => DerivedClassFunc
           requires overrides(DerivedClassFunc, BaseClassFunc)
 

--- a/semantics/cpp/language/execution/expr/name.k
+++ b/semantics/cpp/language/execution/expr/name.k
@@ -13,7 +13,7 @@ module CPP-EXECUTION-EXPR-NAME
      imports CPP-TYPING-SYNTAX
 
      rule <k> ExecName(NoNNS(), X:CId) => lv(lnew(getBase(Entry)), noTrace, T) ...</k>
-          <env>... X |-> (T::CPPType |-> Entry::EnvEntry) ...</env>
+          <env>... X |-> (_::CPPType |-> (T::CPPType, Entry::EnvEntry)) ...</env>
           requires Execution()
 
      rule <k> ExecName(NoNNS(), X:CId) => T ...</k>

--- a/semantics/cpp/language/execution/init.k
+++ b/semantics/cpp/language/execution/init.k
@@ -16,7 +16,7 @@ module CPP-EXECUTION-INIT
      rule Execution() => true
 
      rule <k> initMainThread(EP::String) => initMainThread'(getTU(Base)) ...</k>
-          <odr-defs>... GlobalNamespace() :: Identifier(EP) |-> (_::CPPType |-> Base::SymBase) ...</odr-defs>
+          <odr-defs>... GlobalNamespace() :: Identifier(EP) |-> (_::CPPType |-> (_, Base::SymBase)) ...</odr-defs>
 
      rule <k> callEntryPoint(EP::String, N:Int, Args:K)
                => enterRestrictTU ~> K ~> reval(#callCppEntryPoint(T, getBase(Entry), N, mainArguments, Args)) ~> callAtExit
@@ -26,7 +26,7 @@ module CPP-EXECUTION-INIT
           <curr-tu> Tu::String </curr-tu>
           <tu-id> Tu </tu-id>
           <ns-id> GlobalNamespace() </ns-id>
-          <nenv>... Identifier(EP) |-> (T::CPPType |-> Entry::EnvEntry) ...</nenv>
+          <nenv>... Identifier(EP) |-> (_::CPPType |-> (T::CPPType, Entry::EnvEntry)) ...</nenv>
           <status> _ => mainCalled </status>
 
      syntax Expr ::= #callCppEntryPoint(CPPType, SymBase, Int, CId, K)
@@ -44,7 +44,7 @@ module CPP-EXECUTION-INIT
      rule <k> setupCppEnv(Argc::Int) => .K ...</k>
 
           // adjust environment to C++ form
-          <env>... mainArguments |-> Argv::SymBase => mainArguments |-> (type(arrayType(type(pointerType(type(char))), Argc +Int 1)) |-> envEntry(Argv, false, NoDefArgs())) ...</env>
+          <env>... mainArguments |-> Argv::SymBase => mainArguments |-> (#fun(T::CPPType => T |-> (T, envEntry(Argv, false, NoDefArgs())))(type(arrayType(type(pointerType(type(char))), Argc +Int 1)))) ...</env>
           <types>... mainArguments |-> _ => .Map ...</types>
 
      rule <k> reval(V:PRVal) ~> callAtExit => AtExit:KItem ~> reval(V) ~> callAtExit ...</k>

--- a/semantics/cpp/language/execution/stmt/block.k
+++ b/semantics/cpp/language/execution/stmt/block.k
@@ -87,6 +87,6 @@ module CPP-EXECUTION-STMT-BLOCK
           <curr-tu> Tu::String </curr-tu>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <cenv>... DestructorId(X) |-> (FuncT::CPPType |-> envEntry(... base: Base::SymBase)) ...</cenv>
+          <cenv>... DestructorId(X) |-> (_::CPPType |-> (FuncT::CPPType, envEntry(... base: Base::SymBase))) ...</cenv>
 
 endmodule

--- a/semantics/cpp/language/translation/decl/class.k
+++ b/semantics/cpp/language/translation/decl/class.k
@@ -93,7 +93,7 @@ module CPP-TRANSLATION-DECL-CLASS-DESTRUCTOR
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <cenv>... DestructorId(X) |-> (_::CPPType |-> envEntry(... base: Base::SymBase)) ...</cenv>
+          <cenv>... DestructorId(X) |-> (_::CPPType |-> (_, envEntry(... base: Base::SymBase))) ...</cenv>
 
      // @ref N4296 12.4/11
      // @ref N4778 10.3.6/12
@@ -266,7 +266,7 @@ module CPP-TRANSLATION-DECL-CLASS
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <cenv>... ConstructorId(X) |-> M::TypeMap DestructorId(X) |-> _ ...</cenv>
+          <cenv>... ConstructorId(X) |-> M::Map DestructorId(X) |-> _ ...</cenv>
           <is-aggregate> B:Bool => B andBool notBool some(M, isUserProvidedConstructor) andBool notBool hasVirtualMembers(type(classType(C))) </is-aggregate>
 
      // TODO(dwightguth): implicit exception spec
@@ -542,7 +542,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
           <variant-members> VM::Set </variant-members>
-          <initializers>... X |-> (T |-> I::Init) ...</initializers>
+          <initializers>... X |-> (stripType(T) |-> (_, I::Init)) ...</initializers>
           requires isDeletedDefaultConstructor(X, T, C, FuncT, VM, I)
 
      syntax KItem ::= ".Init"
@@ -555,7 +555,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
           <variant-members> VM::Set </variant-members>
-          <initializers>... X |-> (T |-> I::Init) ...</initializers>
+          <initializers>... X |-> (stripType(T) |-> (_, I::Init)) ...</initializers>
           requires notBool isDeletedDefaultConstructor(X, T, C, FuncT, VM, I)
 
      rule <k> (.K => checkCtorAndDtor(MemInit[C] orDefault .Init, baseClass(C), type(classType(C)), false, NoInit(), type(classType(C)))) ~> figureConstruct(.List, MemInit::Map, (ListItem(C::Class) => .List) _, _, _, _, _) ...</k>
@@ -590,7 +590,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <class-id> M </class-id>
-          <cenv>... ConstructorId(X) |-> Candidates::TypeMap ...</cenv>
+          <cenv>... ConstructorId(X) |-> Candidates::Map ...</cenv>
 
      rule resolve(E:ResolvedExpr) ~> checkCtor(_) => .K
           requires notBool isNotFoundNameRef(E)
@@ -601,7 +601,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <class-id> M </class-id>
-          <cenv>... DestructorId(X) |-> (T::CPPType |-> envEntry(... base: Base::SymBase)) ...</cenv>
+          <cenv>... DestructorId(X) |-> (_::CPPType |-> (T::CPPType, envEntry(... base: Base::SymBase))) ...</cenv>
 
      rule resolve(E:ResolvedExpr) ~> checkDtor(_) => .K
           requires notBool isNotFoundNameRef(E)
@@ -655,7 +655,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <initializers>... X |-> (T |-> I::Init) ...</initializers>
+          <initializers>... X |-> (stripType(T) |-> (_, I::Init)) ...</initializers>
           <variant-members> VM::Set </variant-members>
           requires I =/=K NoInit()
 
@@ -667,7 +667,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <initializers>... X |-> (T |-> I::Init) ...</initializers>
+          <initializers>... X |-> (stripType(T) |-> (_, I::Init)) ...</initializers>
           <variant-members> VM::Set </variant-members>
           requires I ==K NoInit() andBool X in VM
 
@@ -678,7 +678,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <initializers>... X |-> (T |-> I::Init) ...</initializers>
+          <initializers>... X |-> (stripType(T) |-> (_, I::Init)) ...</initializers>
           <variant-members> VM::Set </variant-members>
           requires I ==K NoInit() andBool notBool X in VM
 
@@ -708,7 +708,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           requires hasConstructorThat(type(classType(C)), isTrivialDefaultConstructor)
 
      // @ref n4296 12.1:4.9,4.11
-     rule #isTrivialDefaultConstructor(<class>... <non-static-data-members> ListItem(Class.DataMember(X::CId, T::CPPType)) => .List ...</non-static-data-members> <initializers>... X |-> (T |-> NoInit()) ...</initializers> ...</class>)
+     rule #isTrivialDefaultConstructor(<class>... <non-static-data-members> ListItem(Class.DataMember(X::CId, T::CPPType)) => .List ...</non-static-data-members> <initializers>... X |-> (stripType(T) |-> (_, NoInit())) ...</initializers> ...</class>)
           requires #if isCPPClassType(getMostDerivedArrayElement(T)) #then hasConstructorThat(getMostDerivedArrayElement(T), isTrivialDefaultConstructor) #else true #fi
 
      rule #isTrivialDefaultConstructor(<class>... <base-classes> .List </base-classes> <non-static-data-members> .List </non-static-data-members> ...</class>) => true
@@ -782,7 +782,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
 
      rule hasDestructorThat(t(... st: classType(_ :: Class(_, X::CId, _))) #as T::CPPType, Lbl::TypePredicate) => #hasMethodThat(DestructorId(X), getClassInfo(T), Lbl)
 
-     rule #hasMethodThat(X::CId, <class>... <cenv>... X |-> M::TypeMap ...</cenv> ...</class>, Lbl::TypePredicate)
+     rule #hasMethodThat(X::CId, <class>... <cenv>... X |-> M::Map ...</cenv> ...</class>, Lbl::TypePredicate)
           => some(M, Lbl)
 
      rule #hasMethodThat(...) => false [owise]
@@ -879,7 +879,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <functions>... Base |-> functionObject(_, FuncT::CPPType, _, _) ...</functions>
           requires isMethodVirtual(FuncT)
 
-     rule (cSet(... candidates: Cands::TypeMap, id: Q::QualId) #as C:CandidateSet => resolve(resolveOverload(C, list(ListItem(prv(NullPointer, noTrace, type(pointerType(type(void))))) getSecondDeleteArg(Cands, prv(0, noTrace, type(size_t)))), Name(NoNNS(), operatordelete))))
+     rule (cSet(... candidates: Cands::Map, id: Q::QualId) #as C:CandidateSet => resolve(resolveOverload(C, list(ListItem(prv(NullPointer, noTrace, type(pointerType(type(void))))) getSecondDeleteArg(Cands, prv(0, noTrace, type(size_t)))), Name(NoNNS(), operatordelete))))
           ~> figureDestruct(...)
 
      rule resolve(E:ResolvedExpr) ~> figureDestruct(.List, .List, Res:K) => Res
@@ -1300,18 +1300,18 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
 
      rule getTypesAtOffsetForLayoutInStruct(_, <class>...
                <non-static-data-members>... ListItem(Class.DataMember(X::CId, T::CPPType)) => .List </non-static-data-members>
-               <cenv>... X |-> (_::TypeMap T |-> classOffset(_, FOffset::Int)) ...</cenv>
+               <cenv>... X |-> (_::Map stripType(T) |-> (_, classOffset(_, FOffset::Int))) ...</cenv>
           ...</class>, Offset::Int)
           requires FOffset >Int Offset
 
      rule getTypesAtOffsetForLayoutInStruct(_, <class>...
                <non-static-data-members>... ListItem(Class.DataMember(X::CId, T::CPPType)) => .List </non-static-data-members>
-               <cenv>... X |-> (_::TypeMap T |-> uninitialized) ...</cenv>
+               <cenv>... X |-> (_::Map stripType(T) |-> (_, uninitialized)) ...</cenv>
           ...</class>, Offset::Int)
 
      rule getTypesAtOffsetForLayoutInStruct(T::CPPType, <class>...
                <non-static-data-members>... ListItem(Class.DataMember(X::CId, T'::CPPType)) </non-static-data-members>
-               <cenv>... X |-> (_::TypeMap T' |-> classOffset(_, FOffset::Int)) ...</cenv>
+               <cenv>... X |-> (_::Map stripType(T') |-> (_, classOffset(_, FOffset::Int))) ...</cenv>
           ...</class>, Offset::Int)
           => getTypesAtOffsetForLayout(T', Offset -Int FOffset)
           requires FOffset <=Int Offset
@@ -1323,20 +1323,20 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
      rule getTypesAtOffsetForLayoutInStruct(T::CPPType, <class>...
                <base-classes>... ListItem(t(... st: classType(C::Class)) #as T'::CPPType) => .List </base-classes>
                <non-static-data-members> .List </non-static-data-members>
-               <cenv>... baseClass(C) |-> (_::TypeMap T' |-> classOffset(_, FOffset::Int)) ...</cenv>
+               <cenv>... baseClass(C) |-> (_::Map stripType(T') |-> (_, classOffset(_, FOffset::Int))) ...</cenv>
           ...</class>, Offset::Int)
           requires FOffset >Int Offset
 
      rule getTypesAtOffsetForLayoutInStruct(T::CPPType, <class>...
                <base-classes>... ListItem(t(... st: classType(C::Class)) #as T'::CPPType) => .List </base-classes>
                <non-static-data-members> .List </non-static-data-members>
-               <cenv>... baseClass(C) |-> (_::TypeMap T' |-> uninitialized) ...</cenv>
+               <cenv>... baseClass(C) |-> (_::Map stripType(T') |-> (_, uninitialized)) ...</cenv>
           ...</class>, Offset::Int)
 
      rule getTypesAtOffsetForLayoutInStruct(T::CPPType, <class>...
                <base-classes>... ListItem(t(... st: classType(C::Class)) #as T'::CPPType) </base-classes>
                <non-static-data-members> .List </non-static-data-members>
-               <cenv>... baseClass(C) |-> (_::TypeMap T' |-> classOffset(_, FOffset::Int)) ...</cenv>
+               <cenv>... baseClass(C) |-> (_::Map stripType(T') |-> (_, classOffset(_, FOffset::Int))) ...</cenv>
           ...</class>, Offset::Int)
           => getTypesAtOffsetForLayout(T', Offset -Int FOffset)
           requires FOffset <=Int Offset

--- a/semantics/cpp/language/translation/decl/declarator.k
+++ b/semantics/cpp/language/translation/decl/declarator.k
@@ -116,9 +116,9 @@ module CPP-TRANSLATION-DECL-DECLARATOR
 
      syntax Namespace ::= getInnermostNamespace(NNSVal, Scope) [function]
 
-     rule getPreviousLinkage(X::QualId, T::CPPType, X |-> (T |-> _ _::TypeMap) _::Map, _) => ExternalLinkage
+     rule getPreviousLinkage(X::QualId, T::CPPType, X |-> (stripType(T) |-> _ _::Map) _::Map, _) => ExternalLinkage
 
-     rule getPreviousLinkage(X::QualId, T::CPPType, _, X |-> (T |-> _ _::TypeMap) _::Map) => InternalLinkage
+     rule getPreviousLinkage(X::QualId, T::CPPType, _, X |-> (stripType(T) |-> _ _::Map) _::Map) => InternalLinkage
 
      rule getPreviousLinkage(_, _, _, _) => .K [owise]
 
@@ -279,7 +279,7 @@ module CPP-TRANSLATION-DECL-DECLARATOR
           rule <k> declareObjectWithLinkage(N::Namespace, LN::Namespace, X::CId, t(... st: _:CPPSimpleArrayType) #as T::CPPType, Init::Init, Type::DeclarationType, StaticStorage, S::Set, _, ExternalLinkage) ...</k>
                <curr-tr-tu> Tu::String </curr-tr-tu>
                <tu-id> Tu </tu-id>
-               <externals>... LN :: X |-> ((T'::CPPType => T) |-> declState(Base::SymBase, _)) ...</externals>
+               <externals>... LN :: X |-> ((_::CPPType => stripType(T)) |-> (T'::CPPType => T, declState(Base::SymBase, _))) ...</externals>
                requires isCPPArrayType(T') andBool notBool isCompleteType(T') andBool innerType(T) ==Type innerType(T') andBool getQuals(T) ==K getQuals(T')
 
           // ExternalLinkage, StaticStorage, redeclare complete type
@@ -288,7 +288,7 @@ module CPP-TRANSLATION-DECL-DECLARATOR
                ...</k>
                <curr-tr-tu> Tu::String </curr-tr-tu>
                <tu-id> Tu </tu-id>
-               <externals>... LN :: X |-> (T |-> declState(Base::SymBase, _) _::TypeMap) ...</externals>
+               <externals>... LN :: X |-> (stripType(T) |-> (_, declState(Base::SymBase, _)) _::Map) ...</externals>
                <curr-template-context> noTemplate </curr-template-context>
 
           // InternalLinkage, StaticStorage, redeclare complete type
@@ -297,7 +297,7 @@ module CPP-TRANSLATION-DECL-DECLARATOR
                ...</k>
                <curr-tr-tu> Tu::String </curr-tr-tu>
                <tu-id> Tu </tu-id>
-               <internals>... LN :: X |-> (T::CPPType |-> declState(Base::SymBase, _) _::TypeMap) ...</internals>
+               <internals>... LN :: X |-> (stripType(T::CPPType) |-> (_, declState(Base::SymBase, _)) _::Map) ...</internals>
                <curr-template-context> noTemplate </curr-template-context>
 
           syntax KItem ::= redeclareCompleteType(Namespace, Namespace, CId, CPPType, Init, DeclarationType, Set, CId, SymBase)
@@ -461,14 +461,14 @@ module CPP-TRANSLATION-DECL-DECLARATOR
 
      rule #computeAggArraySize(...
                            fields: (ListItem(Class.DataMember(F:CId, _)) => .List) _,
-                           types: (F |-> (T::CPPType |-> _)) _,
+                           types: (F |-> (_::CPPType |-> (T::CPPType, _))) _,
                            initList: (ListItem(Init::Expr) => .List) _
                            )
           requires (notBool isAggregateType(T) orBool isBraceInit(Init))
 
      rule #computeAggArraySize(...
                            fields: (ListItem(Class.DataMember(F:CId, _)) Fields::List => Class.getNonStaticDataMembers(getClassInfo(T))),
-                           types: (((F |-> (T::CPPType |-> _)) _) #as Types::Map => Class.getDataMembersInitializers(getClassInfo(T))),
+                           types: (((F |-> (_::CPPType |-> (T::CPPType, _))) _) #as Types::Map => Class.getDataMembersInitializers(getClassInfo(T))),
                            initList: ListItem(Init::Expr) _,
                            callStack: (.List => ListItem(kpair(Fields, Types))) _
                            )
@@ -567,13 +567,13 @@ module CPP-TRANSLATION-DECL-DECLARATOR
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <ns-id> N </ns-id>
-          <nenv>... X |-> (_::TypeMap T |-> envEntry(... base: Base:LinkBase)) ...</nenv>
+          <nenv>... X |-> (_::Map stripType(T) |-> (_, envEntry(... base: Base:LinkBase))) ...</nenv>
 
      rule <k> findLinkBase(C:Class :: X::CId, T::CPPType) => r(Base) ...</k>
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <cenv>... X |-> (_::TypeMap T |-> envEntry(... base: Base:LinkBase)) ...</cenv>
+          <cenv>... X |-> (_::Map stripType(T) |-> (_, envEntry(... base: Base:LinkBase))) ...</cenv>
 
      rule <k> allocateDecl2(Q::QualId, CName::CId, T::CPPType, S::Set, r(LBase:LinkBase))
               => allocateDecl3(Q, CName, T, S, LBase, bnew(!I:Int, T, S, static(Tu))) ...</k>

--- a/semantics/cpp/language/translation/decl/initializer.k
+++ b/semantics/cpp/language/translation/decl/initializer.k
@@ -17,7 +17,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER-SYNTAX
 
      syntax KResult ::= "ill-formed"
 
-     syntax TypeMap ::= stripExplicit(TypeMap) [function]
+     syntax Map ::= stripExplicit(Map) [function]
 endmodule
 
 module CPP-TRANSLATION-DECL-INITIALIZER
@@ -109,7 +109,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
                ~> zeroInitClass(Base:LVal, t(_, _, classType(C::Class)), .List, (ListItem(Class.DataMember(X::CId, T::CPPType)) => .List) _, _)
           ...</k>
           <class-id> C </class-id>
-          <cenv>... X |-> (_::CPPType |-> classOffset(NAOffset::Int, Offset::Int)) ...</cenv>
+          <cenv>... X |-> (_::CPPType |-> (_, classOffset(NAOffset::Int, Offset::Int))) ...</cenv>
 
      syntax KItem ::= evalMany(List, List)
 
@@ -297,11 +297,11 @@ module CPP-TRANSLATION-DECL-INITIALIZER
 
      syntax Bool ::= hasInit(CId, Map) [function]
 
-     rule hasInit(X:CId, X |-> M::TypeMap _) => notBool isNoInit(M)
+     rule hasInit(X:CId, X |-> M::Map _) => notBool isNoInit(M)
 
-     syntax Bool ::= isNoInit(TypeMap) [function]
+     syntax Bool ::= isNoInit(Map) [function]
 
-     rule isNoInit(_ |-> NoInit()) => true
+     rule isNoInit(_ |-> (_, NoInit())) => true
 
      rule isNoInit(_ |-> _) => false [owise]
 
@@ -330,7 +330,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
        ~> classAggInit(... base: Base::LVal,
                            fields: (ListItem(Class.DataMember(F:CId, _)) => .List) _,
                            initList: (ListItem(Init::Expr) => .List) _,
-                           initializers: (F |-> (T::CPPType |-> _)) _,
+                           initializers: (F |-> (_::CPPType |-> (T::CPPType, _))) _,
                            class: C::Class)
           requires (notBool isAggregateType(T) orBool isBraceInit(Init))
 
@@ -338,7 +338,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
        ~> classAggInit(... base: Base::LVal,
                            fields: (ListItem(Class.DataMember(F:CId, _)) => .List) _,
                            initList: (ListItem(Init::Expr) _) #as L::List  => .List,
-                           initializers: (F |-> (T::CPPType |-> _)) _,
+                           initializers: (F |-> (_::CPPType |-> (T::CPPType, _))) _,
                            class: C::Class)
           requires isAggregateType(T)
            andBool notBool isBraceInit(Init)
@@ -367,7 +367,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
        ~> classAggInit(... base: Base::LVal,
                            fields: (ListItem(Class.DataMember(F:CId, _)) => .List) _,
                            initList: .List,
-                           initializers: (F |-> (T::CPPType |-> Init::Expr)) _,
+                           initializers: (F |-> (_::CPPType |-> (T::CPPType, Init::Expr))) _,
                            class: C::Class)
 
      syntax Init ::= #evalBraceOrEqualInitializer(class: Class, object: Expr, initializer: Init) [function]
@@ -525,12 +525,12 @@ module CPP-TRANSLATION-DECL-INITIALIZER
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <cenv>... ConstructorId(X) |-> M::TypeMap ...</cenv>
+          <cenv>... ConstructorId(X) |-> M::Map ...</cenv>
 
-     rule stripExplicit(T::CPPType |-> K1:KItem M::TypeMap) => T |-> K1 stripExplicit(M)
+     rule stripExplicit(_::CPPType |-> (T::CPPType, K1:KItem) M::Map) => stripType(T) |-> (T, K1) stripExplicit(M)
           requires notBool isMethodExplicit(T)
 
-     rule stripExplicit(_ |-> _ M::TypeMap) => stripExplicit(M) [owise]
+     rule stripExplicit(_ |-> _ M::Map) => stripExplicit(M) [owise]
 
      rule stripExplicit(.Map) => .Map
 

--- a/semantics/cpp/language/translation/decl/template.k
+++ b/semantics/cpp/language/translation/decl/template.k
@@ -88,7 +88,7 @@ module CPP-TRANSLATION-DECL-TEMPLATE
      rule <k> elaborateDone(K:K) ~> finishTemplate => .K ...</k>
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
-          <templates>... Q |-> (T |-> templateInfo(... body: (_ => K))) ...</templates>
+          <templates>... Q |-> (stripType(T) |-> (_, templateInfo(... body: (_ => K)))) ...</templates>
           <curr-template-context> templateInfo(...id: Q::QualId, type: T::CPPType) </curr-template-context>
 
 
@@ -163,7 +163,7 @@ module CPP-TRANSLATION-DECL-TEMPLATE
 
      rule <k> declareTemplate(T::CPPType) => .K ...</k>
           <curr-template-context> templateInfo(X::QualId, Decls::List, Types::Map, Def::Map, (_ => T), _) </curr-template-context>
-          <templates> Temp:Map => Temp X |-> (T |-> templateInfo(X, Decls, Types, Def, T, .K)) </templates>
+          <templates> Temp:Map => Temp X |-> (stripType(T) |-> (T, templateInfo(X, Decls, Types, Def, T, .K))) </templates>
           requires notBool X, T in_keys(Temp)
 
      rule <k> declareTemplate(T::CPPType) => .K ...</k>
@@ -194,6 +194,6 @@ module CPP-TRANSLATION-DECL-TEMPLATE
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <ns-id> N </ns-id>
-          <nenv>... X |-> (_::TypeMap T |-> Entry::EnvEntry) ...</nenv>
+          <nenv>... X |-> (_::Map stripType(T) |-> (_, Entry::EnvEntry)) ...</nenv>
 
 endmodule

--- a/semantics/cpp/language/translation/decl/using.k
+++ b/semantics/cpp/language/translation/decl/using.k
@@ -5,7 +5,7 @@ module CPP-TRANSLATION-DECL-USING
      imports CPP-SYMLOC-SYNTAX
      imports CPP-SYNTAX
      imports CPP-TYPE-MAP-SYNTAX
-     imports CPP-TYPING-SORTS
+     imports CPP-TYPING-SYNTAX
 
      context UsingDecl(_, HOLE:NNS, _) [result(NNSVal)]
 
@@ -20,7 +20,7 @@ module CPP-TRANSLATION-DECL-USING
           ...</ns>
           <ns>...
             <ns-id> UsingN </ns-id>
-            <nenv>... X |-> UsingM::TypeMap ...</nenv>
+            <nenv>... X |-> UsingM::Map ...</nenv>
           ...</ns>
 
      // using a type
@@ -38,10 +38,10 @@ module CPP-TRANSLATION-DECL-USING
           ...</ns>
 
 
-     syntax TypeMap ::= makeUsing(TypeMap) [function]
+     syntax Map ::= makeUsing(Map) [function]
 
-     rule makeUsing(T::CPPType |-> envEntry(Base::SymBase, _, Args::DefaultArgumentsResult) M::TypeMap)
-          => T |-> envEntry(Base, true, Args) makeUsing(M)
+     rule makeUsing(_::CPPType |-> (T::CPPType, envEntry(Base::SymBase, _, Args::DefaultArgumentsResult)) M::Map)
+          => stripType(T) |-> (T, envEntry(Base, true, Args)) makeUsing(M)
 
      rule makeUsing(.Map) => .Map
 

--- a/semantics/cpp/language/translation/env.k
+++ b/semantics/cpp/language/translation/env.k
@@ -62,7 +62,7 @@ module CPP-TRANSLATION-ENV
          <curr-tr-tu> Tu::String </curr-tr-tu>
          <tu-id> Tu </tu-id>
          <ns-id> N </ns-id>
-         <nenv>... X |-> (_::TypeMap T |-> envEntry(... defaultArgs: A2::DefaultArgumentsResult => #updateDefaultArgs(A1, A2))) ...</nenv>
+         <nenv>... X |-> (_::Map stripType(T) |-> (_, envEntry(... defaultArgs: A2::DefaultArgumentsResult => #updateDefaultArgs(A1, A2)))) ...</nenv>
          requires N =/=K NoNamespace()
 
     rule <k> addToEnv(N:Namespace :: X::CId, T::CPPType, Base::SymBase, IsUsing::Bool)
@@ -71,7 +71,7 @@ module CPP-TRANSLATION-ENV
          <curr-tr-tu> Tu::String </curr-tr-tu>
          <tu-id> Tu </tu-id>
          <ns-id> N </ns-id>
-         <nenv> NE::Map => NE[X <- T |-> envEntry(Base, IsUsing, NoDefArgs())] </nenv>
+         <nenv> NE::Map => NE[X <- stripType(T) |-> (T, envEntry(Base, IsUsing, NoDefArgs()))] </nenv>
          requires N =/=K NoNamespace() andBool notBool isCPPFunctionType(T)
 
     rule <k> addToEnv(NoNamespace() :: X::CId, t(... st: functionType(...)) #as T::CPPType, Base::SymBase, IsUsing::Bool)
@@ -80,12 +80,12 @@ module CPP-TRANSLATION-ENV
          <tr-env> NE::Map => NE[X <- updateFnEnv(NE, X, T, Base, IsUsing)] </tr-env>
 
     rule <k> updateDefaultArguments(NoNamespace() :: X::CId, t(... st: functionType(...)) #as T::CPPType, A1:DefaultArgumentsResult) => .K ...</k>
-         <tr-env>... X |-> (_::TypeMap T |-> envEntry(... defaultArgs: A2::DefaultArgumentsResult => #updateDefaultArgs(A1, A2))) ...</tr-env>
+         <tr-env>... X |-> (_::Map stripType(T) |-> (_, envEntry(... defaultArgs: A2::DefaultArgumentsResult => #updateDefaultArgs(A1, A2)))) ...</tr-env>
 
     rule <k> addToEnv(NoNamespace() :: X::CId, T::CPPType, Base::SymBase, IsUsing::Bool)
              => .K
          ...</k>
-         <tr-env> NE::Map => NE[X <- T |-> envEntry(Base, IsUsing, NoDefArgs())] </tr-env>
+         <tr-env> NE::Map => NE[X <- stripType(T) |-> (T, envEntry(Base, IsUsing, NoDefArgs()))] </tr-env>
          requires notBool isCPPFunctionType(T)
 
     rule <k> addToEnv(C:Class :: X::CId, t(... st: functionType(...)) #as T::CPPType, Base::SymBase, IsUsing::Bool)
@@ -96,13 +96,13 @@ module CPP-TRANSLATION-ENV
 
      rule <k> updateDefaultArguments(C:Class :: X::CId, t(... st: functionType(...)) #as T::CPPType, A1:DefaultArgumentsResult) => .K ...</k>
           <class-id> C </class-id>
-          <cenv>... X |-> (_::TypeMap T |-> envEntry(... defaultArgs: A2::DefaultArgumentsResult => #updateDefaultArgs(A1, A2))) ...</cenv>
+          <cenv>... X |-> (_::Map stripType(T) |-> (_, envEntry(... defaultArgs: A2::DefaultArgumentsResult => #updateDefaultArgs(A1, A2)))) ...</cenv>
 
     rule <k> addToEnv(C:Class :: X::CId, T::CPPType, Base::SymBase, IsUsing::Bool)
              => .K
          ...</k>
          <class-id> C </class-id>
-         <cenv> CE::Map => CE[X <- T |-> envEntry(Base, IsUsing, NoDefArgs())] </cenv>
+         <cenv> CE::Map => CE[X <- stripType(T) |-> (T, envEntry(Base, IsUsing, NoDefArgs()))] </cenv>
          requires notBool isCPPFunctionType(T)
 
      rule getDefaultArgsVals(defArgs(... vals: krlist(Args::List))) => Args
@@ -111,20 +111,20 @@ module CPP-TRANSLATION-ENV
 
      rule getDefaultArgsCats(defArgs(... cats: krlist(Cats::List))) => Cats
 
-     syntax TypeMap ::= updateFnEnv(Map, CId, CPPType, SymBase, Bool) [function]
+     syntax Map ::= updateFnEnv(Map, CId, CPPType, SymBase, Bool) [function]
 
-     rule updateFnEnv(Env::Map, X::CId, T::CPPType, Base::SymBase, IsUsing::Bool) => T |-> envEntry(Base, IsUsing, emptyDefaultArguments(T))
+     rule updateFnEnv(Env::Map, X::CId, T::CPPType, Base::SymBase, IsUsing::Bool) => stripType(T) |-> (T, envEntry(Base, IsUsing, emptyDefaultArguments(T)))
           requires notBool X in_keys(Env)
 
-     rule updateFnEnv(_ X |-> XEnv::TypeMap, X::CId, T::CPPType, Base::SymBase, IsUsing::Bool)
+     rule updateFnEnv(_ X |-> XEnv::Map, X::CId, T::CPPType, Base::SymBase, IsUsing::Bool)
           => #updateFnEnv(XEnv, T, Base, IsUsing)
 
-     syntax TypeMap ::= #updateFnEnv(TypeMap, CPPType, SymBase, Bool) [function]
+     syntax Map ::= #updateFnEnv(Map, CPPType, SymBase, Bool) [function]
 
-     rule #updateFnEnv(XEnv::TypeMap T |-> Entry:EnvEntry, T::CPPType, Base::SymBase, IsUsing::Bool)
-          => XEnv T |-> #fun(envEntry(... base: _ => Base, using: _ => IsUsing))(Entry)
+     rule #updateFnEnv(XEnv::Map stripType(T) |-> (_, Entry:EnvEntry), T::CPPType, Base::SymBase, IsUsing::Bool)
+          => XEnv stripType(T) |-> (T, #fun(envEntry(... base: _ => Base, using: _ => IsUsing))(Entry))
 
-     rule #updateFnEnv(XEnv::TypeMap, T::CPPType, Base::SymBase, IsUsing::Bool) => XEnv T |-> envEntry(Base, IsUsing, emptyDefaultArguments(T)) [owise]
+     rule #updateFnEnv(XEnv::Map, T::CPPType, Base::SymBase, IsUsing::Bool) => XEnv stripType(T) |-> (T, envEntry(Base, IsUsing, emptyDefaultArguments(T))) [owise]
 
      syntax DefaultArgumentsResult ::= #updateDefaultArgs(newArgs: DefaultArgumentsResult, oldArgs: DefaultArgumentsResult) [function]
 

--- a/semantics/cpp/language/translation/expr/new.k
+++ b/semantics/cpp/language/translation/expr/new.k
@@ -4,11 +4,10 @@ module CPP-TRANSLATION-EXPR-NEW-SYNTAX
      imports MAP
      imports COMMON-SORTS
      imports CPP-DYNAMIC-SORTS
-     imports CPP-TYPE-MAP-SORTS
      imports CPP-TYPING-SORTS
      syntax KItem ::= lookupAllocationFunction(CId, CPPType, Bool)
 
-     syntax List ::= getSecondDeleteArg(TypeMap, PRVal) [function]
+     syntax List ::= getSecondDeleteArg(Map, PRVal) [function]
 endmodule
 
 module CPP-TRANSLATION-EXPR-NEW
@@ -129,12 +128,12 @@ module CPP-TRANSLATION-EXPR-NEW
 
      // </group>
 
-     rule getSecondDeleteArg(M::TypeMap, V::PRVal)
+     rule getSecondDeleteArg(M::Map, V::PRVal)
           => #getSecondDeleteArg(M, func(type(void), ptr(type(void))), func(type(void), ptr(type(void)), type(size_t)), V)
 
-     syntax List ::= #getSecondDeleteArg(TypeMap, CPPType, CPPType, PRVal) [function]
+     syntax List ::= #getSecondDeleteArg(Map, CPPType, CPPType, PRVal) [function]
 
-     rule #getSecondDeleteArg((T1 |-> _) (T2 |-> _) M::TypeMap, T1::CPPType, T2::CPPType, V::PRVal) => ListItem(V)
+     rule #getSecondDeleteArg((stripType(T1) |-> _) (stripType(T2) |-> _) M::Map, T1::CPPType, T2::CPPType, V::PRVal) => ListItem(V)
 
      rule #getSecondDeleteArg(...) => .List [owise]
 
@@ -145,7 +144,7 @@ module CPP-TRANSLATION-EXPR-NEW
           requires isCPPPointerType(type(V)) andBool #fun(InnerT::CPPType => notBool isCPPClassType(InnerT) orBool notBool hasDestructorThat(InnerT, isVirtualDestructor))(innerType(type(V)))
 
      rule (
-            cSet(Cands::TypeMap, Q::QualId) #as C:CandidateSet
+            cSet(Cands::Map, Q::QualId) #as C:CandidateSet
             => resolveOverload(
                  C,
                  list(

--- a/semantics/cpp/language/translation/name.k
+++ b/semantics/cpp/language/translation/name.k
@@ -142,7 +142,7 @@ module CPP-TRANSLATION-NAME
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <ns-id> N </ns-id>
-          <nenv>... X |-> M::TypeMap ...</nenv>
+          <nenv>... X |-> M::Map ...</nenv>
           requires envMask(X |-> M, X, Mask)
 
      rule <k> nameLookupInNamespace(X::CId, N::Namespace, NoTag(), Mask::Set) => nsRef(NS) ...</k>
@@ -162,20 +162,20 @@ module CPP-TRANSLATION-NAME
      rule <k> nameLookupInNamespace(X::CId, N::Namespace, NoTag(), Mask::Set) => templateRef(N :: X, T) ...</k>
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
-          <templates>... N :: X |-> (_::TypeMap T::CPPType |-> _) ...</templates>
+          <templates>... N :: X |-> (_::Map _::CPPType |-> (T::CPPType, _)) ...</templates>
           requires isCPPClassType(T) andBool type in Mask
 
      rule <k> nameLookupInNamespace(X::CId, N::Namespace, Tag::Tag, Mask::Set) => templateRef(N :: X, T) ...</k>
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
-          <templates>... N :: X |-> (_::TypeMap T::CPPType |-> _) ...</templates>
+          <templates>... N :: X |-> (_::Map (_::CPPType |-> (T::CPPType, _))) ...</templates>
           requires isCPPClassType(T) andBool getTag(T) ==K Tag andBool type in Mask
 
-     rule <k> nameLookupInNamespace(X::CId, N::Namespace, NoTag(), Mask::Set) => cSet(T |-> I M, N :: X) ...</k>
+     rule <k> nameLookupInNamespace(X::CId, N::Namespace, NoTag(), Mask::Set) => cSet(stripType(T) |-> (T, I) M, N :: X) ...</k>
           <curr-tr-tu> Tu::String </curr-tr-tu>
           <tu-id> Tu </tu-id>
           <nenv> NE::Map </nenv>
-          <templates>... N :: X |-> (T::CPPType |-> I::TemplateInfo M::TypeMap) ...</templates>
+          <templates>... N :: X |-> (_::CPPType |-> (T::CPPType, I::TemplateInfo) M::Map) ...</templates>
           requires isCPPFunctionType(T) andBool notBool X in_keys(NE)
                andBool function in Mask
 
@@ -193,18 +193,18 @@ module CPP-TRANSLATION-NAME
      syntax Bool ::= templateMask(Map, QualId, Set) [function]
                    | envMask(Map, CId, Set) [function]
 
-     rule templateMask((N :: X |-> ((T::CPPType |-> _) _::TypeMap)) _, N::NNSVal :: X::CId, Mask::Set)
+     rule templateMask((N :: X |-> ((_::CPPType |-> (T::CPPType, _)) _::Map)) _, N::NNSVal :: X::CId, Mask::Set)
           => function in Mask
           requires isCPPFunctionType(T)
 
-     rule templateMask((N :: X |-> ((T::CPPType |-> _) _::TypeMap)) _, N::NNSVal :: X::CId, Mask::Set)
+     rule templateMask((N :: X |-> ((_::CPPType |-> (T::CPPType, _)) _::Map)) _, N::NNSVal :: X::CId, Mask::Set)
           => type in Mask
           requires isCPPClassType(T)
 
      rule templateMask((N :: X |-> _) _, N::NNSVal :: X::CId, Mask::Set)
           => variable in Mask [owise]
 
-     rule envMask((X |-> ((T::CPPType |-> _) _::TypeMap)) _, X::CId, Mask::Set)
+     rule envMask((X |-> ((_::CPPType |-> (T::CPPType, _)) _::Map)) _, X::CId, Mask::Set)
           => function in Mask
           requires isCPPFunctionType(T)
 
@@ -236,7 +236,7 @@ module CPP-TRANSLATION-NAME
           requires variable in Mask
 
      rule <k> lookupNameInBlock(X::CId, NoTag(), Mask::Set) => cSet(S, NoNamespace() :: X) ...</k>
-          <tr-env>... X |-> S::TypeMap ...</tr-env>
+          <tr-env>... X |-> S::Map ...</tr-env>
           requires envMask(X |-> S, X, Mask)
 
      rule <k> lookupNameInBlock(X::CId, _, Mask::Set) => T ...</k>
@@ -275,7 +275,7 @@ module CPP-TRANSLATION-NAME
 
      syntax Expr ::= resolveClassSet(Expr) [strict]
 
-     rule resolveClassSet(classSet(M:TypeMap, X::QualId, _)) => cSet(M, X)
+     rule resolveClassSet(classSet(M:Map, X::QualId, _)) => cSet(M, X)
 
      rule resolveClassSet(classSet(T:CPPType, _, _)) => T
 
@@ -286,7 +286,7 @@ module CPP-TRANSLATION-NAME
      // lookup member in class (and base-classes)
      rule <k> #lookupMember(X::CId, C::Class, _, NoTag(), Mask::Set) => classSet(S, C :: X, SetItem(C)) ...</k>
           <class-id> C </class-id>
-          <cenv>... X |-> S::TypeMap ...</cenv>
+          <cenv>... X |-> S::Map ...</cenv>
           requires envMask(X |-> S, X, Mask)
 
      rule <k> #lookupMember(X::CId, C::Class, _, _, Mask::Set) => classSet(T, C :: X, SetItem(C)) ...</k>
@@ -390,7 +390,7 @@ module CPP-TRANSLATION-NAME
 
      rule (.K => qualifiedNameLookup(X, C, defaultMask)) ~> CallExpr(V:Val . no-template Name(C:NNSVal, X::CId), _, _)
 
-     rule cSet(Y::TypeMap, X::QualId) ~> CallExpr(E::Expr, Args::StrictList, krlist(.List))
+     rule cSet(Y::Map, X::QualId) ~> CallExpr(E::Expr, Args::StrictList, krlist(.List))
           => resolveOverload(cSet(Y, X), Args, E)
 
      rule (.K => qualifiedNameLookup(X, C, defaultMask)) ~> (lv(_, _, t(... st: classType(C::Class))) #Or xv(_, _, t(... st: classType(C::Class))) #Or prv(_, _, t(... st: classType(C::Class)))) . no-template Name(NoNNS(), X::CId)
@@ -528,24 +528,24 @@ module CPP-TRANSLATION-NAME
 
      rule isDependentName(_, .List, .List) => false
 
-     rule <k> false ~> argDependentNameLookup(X::CId, Args::StrictList, Types::StrictList, cSet(Y::TypeMap, QX::QualId)) => cSet(Y, QX) ...</k>
+     rule <k> false ~> argDependentNameLookup(X::CId, Args::StrictList, Types::StrictList, cSet(Y::Map, QX::QualId)) => cSet(Y, QX) ...</k>
            <tr-env> Env::Map </tr-env>
            requires hasSpecialDeclInArgLookup(X, Y, Env)
 
-     syntax Bool ::= hasSpecialDeclInArgLookup(CId, TypeMap, Map) [function]
+     syntax Bool ::= hasSpecialDeclInArgLookup(CId, Map, Map) [function]
 
      // 3.4.2:3.2
-     rule hasSpecialDeclInArgLookup(X::CId, _, _::Map (X |-> ((T::CPPType |-> envEntry(... using: false)) _::TypeMap))) => true
+     rule hasSpecialDeclInArgLookup(X::CId, _, _::Map (X |-> ((_::CPPType |-> (T::CPPType, envEntry(... using: false))) _::Map))) => true
           requires isCPPFunctionType(T)
 
-     rule hasSpecialDeclInArgLookup(_, T::CPPType |-> _, _) => true
+     rule hasSpecialDeclInArgLookup(_, _::CPPType |-> (T::CPPType, _), _) => true
           requires notBool isCPPFunctionType(T)
 
      rule hasSpecialDeclInArgLookup(_, _, _) => false [owise]
 
      // associated namespaces
      rule <k> (.K => getFunctionAddressTypes(Args))
-              ~> false ~> argDependentNameLookup(X::CId, list(Args::List), krlist(Types::List), cSet(... candidates: Y::TypeMap)) ...</k>
+              ~> false ~> argDependentNameLookup(X::CId, list(Args::List), krlist(Types::List), cSet(... candidates: Y::Map)) ...</k>
           <tr-env> Env::Map </tr-env>
           requires notBool hasSpecialDeclInArgLookup(X, Y, Env)
 
@@ -562,7 +562,7 @@ module CPP-TRANSLATION-NAME
 
      rule (.K => nameLookup(X, NoTag(), defaultMask)) ~> getFunctionAddressTypes((ListItem(Name(NoNNS(), X::CId)) => .List) _)
 
-     rule (cSet(... candidates: M::TypeMap) => .K) ~> getFunctionAddressTypes(_) ~> false ~> argDependentNameLookup(_, _, krlist(_::List (.List => filterList(keys_list(M), #klabel(`isCPPFunctionType`)))), _)
+     rule (cSet(... candidates: M::Map) => .K) ~> getFunctionAddressTypes(_) ~> false ~> argDependentNameLookup(_, _, krlist(_::List (.List => filterList(keys_list(M), #klabel(`isCPPFunctionType`)))), _)
 
      rule getFunctionAddressTypes((ListItem(N::Init) => .List) _)
           requires notBool isName(N) andBool notBool isAddressOfName(N)
@@ -692,32 +692,32 @@ module CPP-TRANSLATION-NAME
 
      rule filterNonMemberLookupSet(notFound(_) #as C::CandidateSet, _, _) => C
 
-     rule filterNonMemberLookupSet(cSet(M::TypeMap, Q::QualId), T::CPPType)
+     rule filterNonMemberLookupSet(cSet(M::Map, Q::QualId), T::CPPType)
           => #if isCPPClassType(T) #then cSet(stripMemberFunctions(M), Q) #else cSet(stripEnum1(stripMemberFunctions(M), T), Q) #fi
 
-     rule filterNonMemberLookupSet(cSet(M::TypeMap, Q::QualId), T1::CPPType, T2::CPPType)
+     rule filterNonMemberLookupSet(cSet(M::Map, Q::QualId), T1::CPPType, T2::CPPType)
           => #if isCPPClassType(T1) orBool isCPPClassType(T2) #then cSet(stripMemberFunctions(M), Q) #else cSet(stripEnum1(stripEnum2(stripMemberFunctions(M), T2), T1), Q) #fi
 
-     syntax TypeMap ::= stripMemberFunctions(TypeMap) [function]
+     syntax Map ::= stripMemberFunctions(Map) [function]
 
-     rule stripMemberFunctions(M::TypeMap T::CPPType |-> _) => stripMemberFunctions(M)
+     rule stripMemberFunctions(M::Map _::CPPType |-> (T::CPPType, _)) => stripMemberFunctions(M)
           requires isCPPFunctionType(T) andBool isFunctionMember(T)
 
      rule stripMemberFunctions(.Map) => .Map
 
-     rule stripMemberFunctions(M::TypeMap T::CPPType |-> K:KItem) => T |-> K stripMemberFunctions(M) [owise]
+     rule stripMemberFunctions(M::Map _::CPPType |-> (T::CPPType, K:KItem)) => stripType(T) |-> (T, K) stripMemberFunctions(M) [owise]
 
-     syntax TypeMap ::= stripEnum1(TypeMap, CPPType) [function]
-                  | stripEnum2(TypeMap, CPPType) [function]
+     syntax Map ::= stripEnum1(Map, CPPType) [function]
+                  | stripEnum2(Map, CPPType) [function]
 
      syntax Bool ::= stripEnum(Int, List, CPPType) [function]
 
-     rule stripEnum1(M::TypeMap T::CPPType |-> K:KItem, cppEnumType #as T1::CPPType)
-          => #if stripEnum(0, getParams(T), T1) #then .Map #else T |-> K #fi stripEnum1(M, T1)
+     rule stripEnum1(M::Map _::CPPType |-> (T::CPPType, K:KItem), cppEnumType #as T1::CPPType)
+          => #if stripEnum(0, getParams(T), T1) #then .Map #else stripType(T) |-> (T, K) #fi stripEnum1(M, T1)
           requires isCPPFunctionType(T)
 
-     rule stripEnum2(M::TypeMap T::CPPType |-> K:KItem, cppEnumType #as T2::CPPType)
-          => #if stripEnum(1, getParams(T), T2) #then .Map #else T |-> K #fi stripEnum1(M, T2)
+     rule stripEnum2(M::Map _::CPPType |-> (T::CPPType, K:KItem), cppEnumType #as T2::CPPType)
+          => #if stripEnum(1, getParams(T), T2) #then .Map #else stripType(T) |-> (T, K) #fi stripEnum1(M, T2)
           requires isCPPFunctionType(T)
 
      rule stripEnum(I::Int, L::List, T::CPPType)
@@ -727,9 +727,9 @@ module CPP-TRANSLATION-NAME
 
      rule stripEnum2(.Map, _) => .Map
 
-     rule stripEnum1(M::TypeMap T::CPPType |-> K:KItem, T1::CPPType) => T |-> K stripEnum1(M, T1) [owise]
+     rule stripEnum1(M::Map _::CPPType |-> (T::CPPType, K:KItem), T1::CPPType) => stripType(T) |-> (T, K) stripEnum1(M, T1) [owise]
 
-     rule stripEnum2(M::TypeMap T::CPPType |-> K:KItem, T2::CPPType) => T |-> K stripEnum2(M, T2) [owise]
+     rule stripEnum2(M::Map _::CPPType |-> (T::CPPType, K:KItem), T2::CPPType) => stripType(T) |-> (T, K) stripEnum2(M, T2) [owise]
 
      rule addBuiltinCandidates(operator,, E1::Expr, _, _, E2::Expr, _, _, C1:CandidateSet, C2:CandidateSet)
           => resolveEmptyOverload(cSetUnion2(C1, C2), list(ListItem(E1) ListItem(E2)), Comma(E1, E2), BinaryOperator(operator,, E1, E2))
@@ -786,14 +786,14 @@ module CPP-TRANSLATION-NAME
 
      syntax CandidateSet ::= pairwiseReturning(CPPType, Set, Expr, OpId) [function]
                            | identicalReturning(CPPType, Set, Expr, OpId) [function]
-                           | makeSet(TypeMap, OpId) [function]
+                           | makeSet(Map, OpId) [function]
 
      syntax Set ::= enumTypesFrom(CPPType) [function]
                   | pointerTypesFrom(CPPType) [function]
                   | "promotedArithmeticTypes" [function]
                   | "promotedIntegralTypes" [function]
 
-     syntax TypeMap ::= #identicalReturning(CPPType, Set, Expr) [function]
+     syntax Map ::= #identicalReturning(CPPType, Set, Expr) [function]
                   | #pairwiseReturning(CPPType, Set, Set, Expr) [function]
                   | #pairwiseReturning2(CPPType, CPPType, Set, Expr) [function]
 
@@ -824,13 +824,13 @@ module CPP-TRANSLATION-NAME
           SetItem(type(unsigned-long-long))
           SetItem(type(unsigned-oversized))
 
-     rule makeSet(M::TypeMap, O::OpId) => cSet(M, NoNamespace() :: O)
+     rule makeSet(M::Map, O::OpId) => cSet(M, NoNamespace() :: O)
 
      rule identicalReturning(Ret::CPPType, S::Set, E::Expr, O::OpId)
           => makeSet(#identicalReturning(Ret, S, E), O)
 
      rule #identicalReturning(Ret::CPPType, SetItem(T::CPPType) S::Set, E::Expr)
-          => func(Ret, T, T) |-> builtinOp(E) #identicalReturning(Ret, S, E)
+          => #fun(F::CPPType => stripType(F) |-> (F, builtinOp(E)))(func(Ret, T, T)) #identicalReturning(Ret, S, E)
 
      rule #identicalReturning(...) => .Map [owise]
 
@@ -845,7 +845,7 @@ module CPP-TRANSLATION-NAME
      rule #pairwiseReturning(...) => .Map [owise]
 
      rule #pairwiseReturning2(Ret::CPPType, L::CPPType, SetItem(R::CPPType) S::Set, E::Expr)
-          => func(Ret, L, R) |-> builtinOp(E) #pairwiseReturning2(Ret, L, S, E)
+          => #fun(F::CPPType => stripType(F) |-> (F, builtinOp(E)))(func(Ret, L, R)) #pairwiseReturning2(Ret, L, S, E)
 
      rule #pairwiseReturning2(...) => .Map [owise]
 

--- a/semantics/cpp/language/translation/overloading.k
+++ b/semantics/cpp/language/translation/overloading.k
@@ -1,14 +1,13 @@
 module CPP-TRANSLATION-OVERLOADING-SYNTAX
      imports COMPAT-SYNTAX
      imports CPP-DYNAMIC-SORTS
-     imports CPP-TYPE-MAP-SORTS
      imports CPP-TYPING-SORTS
      imports CPP-TRANSLATION-TYPING-EXPR-SORTS
      imports CPP-TRANSLATION-VALUE-CATEGORY-SORTS
 
      syntax ValResult ::= CandidateSet
 
-     syntax CandidateSet ::= cSet(candidates: TypeMap, id: QualId)
+     syntax CandidateSet ::= cSet(candidates: Map, id: QualId)
 
      syntax Expr ::= resolveOverload(CandidateSet, StrictList, Expr)
                    | resolveConversionOverload(CandidateSet, StrictList, Expr, CPPType)
@@ -118,24 +117,24 @@ module CPP-TRANSLATION-OVERLOADING
 
      rule cSetUnion(E::Expr, notFound(_)) => E
 
-     rule cSetUnion(cSet(M1::TypeMap, QX::QualId), cSet(M2::TypeMap, QX)) => cSet(M1 M2, QX)
+     rule cSetUnion(cSet(M1::Map, QX::QualId), cSet(M2::Map, QX)) => cSet(M1 M2, QX)
 
      // function version
      rule cSetUnion2(notFound(_), E::CandidateSet) => E
 
      rule cSetUnion2(E::CandidateSet, notFound(_)) => E
 
-     rule cSetUnion2(cSet(M1::TypeMap, QX::QualId), cSet(M2::TypeMap, QX)) => cSet(M1 M2, QX)
+     rule cSetUnion2(cSet(M1::Map, QX::QualId), cSet(M2::Map, QX)) => cSet(M1 M2, QX)
 
      context #resolveOverload(... types: (HOLE:StrictList => types(HOLE)))
 
      context #resolveOverload(... cats: (HOLE:StrictList => cats(HOLE)))
 
-     rule #resolveOverload(cSet(... candidates: (T::CPPType |-> envEntry(... defaultArgs: DA::DefaultArgumentsResult) => .Map) _), list(Args::List), krlist(Types::List), krlist(Cats::List), _, _)
+     rule #resolveOverload(cSet(... candidates: (_::CPPType |-> (T::CPPType, envEntry(... defaultArgs: DA::DefaultArgumentsResult)) => .Map) _), list(Args::List), krlist(Types::List), krlist(Cats::List), _, _)
           requires isCPPFunctionType(T) andBool (notBool acceptsNArgs(size(Args), T, getDefaultArgsVals(DA))
             orBool notViableTypes(T, Types, getDefaultArgsTypes(DA), Cats, getDefaultArgsCats(DA)))
 
-     rule #resolveOverload(cSet(... candidates: (T::CPPType |-> builtinOp(_) => .Map) _), list(Args::List), krlist(Types::List), krlist(Cats::List), _, _)
+     rule #resolveOverload(cSet(... candidates: (_::CPPType |-> (T::CPPType, builtinOp(_)) => .Map) _), list(Args::List), krlist(Types::List), krlist(Cats::List), _, _)
           requires isCPPFunctionType(T) andBool #fun(DA::DefaultArgumentsResult =>
                notBool acceptsNArgs(size(Args), T, getDefaultArgsVals(DA))
                  orBool notViableTypes(T, Types, getDefaultArgsTypes(DA), Cats, getDefaultArgsCats(DA)))
@@ -278,7 +277,7 @@ module CPP-TRANSLATION-OVERLOADING
 
      rule computeUDC(t(... st: classType(P::Class)), t(... st: classType(A::Class)), C::ValueCategory) => resolveUDC(ListItem(computeUDCFrom(type(classType(P)), A, getClassInfo(A), C)) ListItem(computeUDCTo(P, getClassInfo(P), type(classType(A)), C)), .List)
 
-     rule computeUDCTo(_ :: Class(_, X::CId, _) #as P::Class, <class>... <cenv>... ConstructorId(X) |-> M::TypeMap ...</cenv> ...</class>, A::CPPType, C::ValueCategory)
+     rule computeUDCTo(_ :: Class(_, X::CId, _) #as P::Class, <class>... <cenv>... ConstructorId(X) |-> M::Map ...</cenv> ...</class>, A::CPPType, C::ValueCategory)
           => resolveUDC(#computeUDCTo(P, keys_list(stripExplicit(M)), A, C), .List)
 
      rule computeUDCFrom(P::CPPType, A::Class, <class>... <conversion-functions> L::List </conversion-functions> ...</class>, C::ValueCategory)
@@ -446,13 +445,13 @@ module CPP-TRANSLATION-OVERLOADING
 
      // do not actually perform overload resolution, this was a function call
      // in which the postfix expression was a function pointer
-     rule #resolveOverload(cSet(... candidates: T::CPPType |-> envEntry(... base: Base::SymBase), id: X::QualId), list(Args::List), _, _, E::Expr, _)
+     rule #resolveOverload(cSet(... candidates: _::CPPType |-> (T::CPPType, envEntry(... base: Base::SymBase)), id: X::QualId), list(Args::List), _, _, E::Expr, _)
           => Odr.newUse(Base)
           ~> updateExternalUses(Base)
           ~> checkAccess(CallExpr(lv(lnew(Base), hasTrace(E), T), list(Args), krlist(getDefaultArgsVals(emptyDefaultArguments(innerType(T))))))
           requires isCPPPointerType(T) andBool isCPPFunctionType(innerType(T)) andBool Base =/=K nonStatic
 
-     rule #resolveOverload(cSet(... candidates: T::CPPType |-> envEntry(... base: nonStatic)), list(Args::List), _, _, E::Expr, _)
+     rule #resolveOverload(cSet(... candidates: _::CPPType |-> (T::CPPType, envEntry(... base: nonStatic))), list(Args::List), _, _, E::Expr, _)
           => checkAccess(CallExpr(le(E, hasTrace(E), T), list(Args), krlist(getDefaultArgsVals(emptyDefaultArguments(innerType(T))))))
           requires isCPPPointerType(T) andBool isCPPFunctionType(innerType(T))
 
@@ -466,29 +465,29 @@ module CPP-TRANSLATION-OVERLOADING
      rule bestViable(T::CPPType, builtinOp(E::Expr)) ~> #resolveOverload(...) => E
 
      rule (.K => computeBestViable(M, Types, Cats, O))
-          ~> #resolveOverload(cSet(... candidates: M::TypeMap), list(Args::List), krlist(Types::List), krlist(Cats::List), _, O::OverloadType)
+          ~> #resolveOverload(cSet(... candidates: M::Map), list(Args::List), krlist(Types::List), krlist(Cats::List), _, O::OverloadType)
           requires allViable(M, size(Args), Types, Cats) [owise] //allViable is expensive so we evaluate this rule late in order to avoid recomputing it over and over unnecessarily
 
-     syntax Bool ::= allViable(cands: TypeMap, Int, List, List) [function]
+     syntax Bool ::= allViable(cands: Map, Int, List, List) [function]
 
-     rule allViable(T::CPPType |-> envEntry(... defaultArgs: DA::DefaultArgumentsResult) M::TypeMap, NArgs::Int, Types::List, Cats::List)
+     rule allViable(_::CPPType |-> (T::CPPType, envEntry(... defaultArgs: DA::DefaultArgumentsResult)) M::Map, NArgs::Int, Types::List, Cats::List)
           => isCPPFunctionType(T) andBool acceptsNArgs(NArgs, T, getDefaultArgsVals(DA))
                andBool notBool notViableTypes(T, Types, getDefaultArgsTypes(DA), Cats, getDefaultArgsCats(DA))
                andBool allViable(M, NArgs, Types, Cats)
 
      // TODO(traiansf): properly resolve default arguments for templates
-     rule allViable(T::CPPType |-> Val:KItem M::TypeMap, NArgs::Int, Types::List, Cats::List)
+     rule allViable(_::CPPType |-> (T::CPPType, Val:KItem) M::Map, NArgs::Int, Types::List, Cats::List)
           => isCPPFunctionType(T) andBool #fun(DA::DefaultArgumentsResult =>
                acceptsNArgs(NArgs, T, getDefaultArgsVals(DA))
                andBool notBool notViableTypes(T, Types, getDefaultArgsTypes(DA), Cats, getDefaultArgsCats(DA)))(emptyDefaultArguments(T))
                andBool allViable(M, NArgs, Types, Cats)
           requires isTemplateSpecialization(Val) orBool isBuiltinOp(Val)
 
-     rule allViable(T::CPPType |-> templateInfo(...) _, _, _, _) => false
+     rule allViable(_::CPPType |-> (T::CPPType, templateInfo(...)) _, _, _, _) => false
 
      rule allViable(... cands: .Map) => true
 
-     syntax KItem ::= computeBestViable(TypeMap, List, List, OverloadType) [function]
+     syntax KItem ::= computeBestViable(Map, List, List, OverloadType) [function]
                     | #computeBestViable(CPPType, K, List, List, List, OverloadType, List) [function]
                     | checkIsBest(CPPType, K, List, List, OverloadType, List) [function]
                     | bestViable(CPPType, K)
@@ -496,7 +495,7 @@ module CPP-TRANSLATION-OVERLOADING
 
      rule computeBestViable(.Map, _, _, _) => noBestViable
 
-     rule computeBestViable(T::CPPType |-> K:KItem M::TypeMap, Types::List, Cats::List, O::OverloadType)
+     rule computeBestViable(_::CPPType |-> (T::CPPType, K:KItem) M::Map, Types::List, Cats::List, O::OverloadType)
           => #computeBestViable(T, K, Map2List(M), Types, Cats, O, .List)
 
      rule #computeBestViable(
@@ -820,14 +819,14 @@ module CPP-TRANSLATION-OVERLOADING
      // normally this is ill formed, but it can be well formed in some cases such as operator overloading of certain operators
      rule noBestViable ~> #resolveOverload(... cands: cSet(... id: X::QualId)) => notFound(getId(X))
 
-     rule #resolveOverload(... cands: cSet(... candidates: (T::CPPType => adjustFunctionType(T)) |-> _:TemplateInfo))
+     rule #resolveOverload(... cands: cSet(... candidates: (_::CPPType => stripType(adjustFunctionType(T))) |-> (T::CPPType => adjustFunctionType(T), _:TemplateInfo)))
           requires isCPPFunctionType(T) andBool notBool isAdjustedType(T)
 
      // TODO(traiansf): properly resolve default arguments for templates
      rule (lv(loc(Base::SymBase, 0), _, _) => .K)
           ~> bestViable(T::CPPType, (_ => envEntry(Base, false, emptyDefaultArguments(T))))
 
-     rule resolveUniqueDecl(cSet(... candidates: T::CPPType |-> envEntry(... base: Base::SymBase), id: X::QualId), E::Expr, _)
+     rule resolveUniqueDecl(cSet(... candidates: _::CPPType |-> (T::CPPType, envEntry(... base: Base::SymBase)), id: X::QualId), E::Expr, _)
           => Odr.newUse(Base)
           ~> updateExternalUses(Base)
           ~> lv(lnew(Base), hasTrace(E), T)
@@ -835,22 +834,22 @@ module CPP-TRANSLATION-OVERLOADING
                andBool notBool isCPPRefType(T)
                andBool notBool isMemberBase(Base)
 
-     rule resolveUniqueDecl(cSet(... candidates: T::CPPType |-> envEntry(... base: nonStatic)), E::Expr, _) => le(E, hasTrace(E), T)
+     rule resolveUniqueDecl(cSet(... candidates: _::CPPType |-> (T::CPPType, envEntry(... base: nonStatic))), E::Expr, _) => le(E, hasTrace(E), T)
 
      // resolve anonymous union member lookup
-     rule resolveUniqueDecl(cSet(... candidates: _ |-> envEntry(... base: memberBase(unnamedObject(C::Class), X::CId, _))), _, _)
+     rule resolveUniqueDecl(cSet(... candidates: _ |-> (_, envEntry(... base: memberBase(unnamedObject(C::Class), X::CId, _)))), _, _)
           => Name(NoNNS(), unnamedObject(C)) . no-template Name(NoNNS(), X)
 
-     rule resolveUniqueDecl(cSet(T::CPPType |-> _:ClassOffset, C:Class :: X::CId), E::Expr, false) => le((*This()) . no-template Name(C, X), hasTrace(E), T)
+     rule resolveUniqueDecl(cSet(_::CPPType |-> (T::CPPType, _:ClassOffset), C:Class :: X::CId), E::Expr, false) => le((*This()) . no-template Name(C, X), hasTrace(E), T)
 
-     rule resolveUniqueDecl(cSet(T::CPPType |-> _:ClassOffset, C:Class :: X::CId), E::Expr, true)
+     rule resolveUniqueDecl(cSet(_::CPPType |-> (T::CPPType, _:ClassOffset), C:Class :: X::CId), E::Expr, true)
           => dataMemberValue(memberPointer(C, X, T), hasTrace(E), T)
 
-     rule <k> resolveUniqueDecl(cSet(... candidates: T::CPPType |-> envEntry(... base: Base::SymBase)), E::Expr, _) => le(E, hasTrace(E), T) ...</k>
+     rule <k> resolveUniqueDecl(cSet(... candidates: _::CPPType |-> (T::CPPType, envEntry(... base: Base::SymBase))), E::Expr, _) => le(E, hasTrace(E), T) ...</k>
           <references> Refs::Map </references>
           requires isCPPRefType(T) andBool notBool loc(Base, 0) in_keys(Refs)
 
-     rule <k> resolveUniqueDecl(cSet(... candidates: T::CPPType |-> envEntry(... base: Base::SymBase)), E::Expr, _) => lv(lnew(Base), hasTrace(E), T) ...</k>
+     rule <k> resolveUniqueDecl(cSet(... candidates: _::CPPType |-> (T::CPPType, envEntry(... base: Base::SymBase))), E::Expr, _) => lv(lnew(Base), hasTrace(E), T) ...</k>
           <references>... loc(Base, 0) |-> _ ...</references>
           requires isCPPRefType(T)
 

--- a/semantics/linking/cpp-resolution.k
+++ b/semantics/linking/cpp-resolution.k
@@ -14,6 +14,7 @@ module LINKING-CPP-RESOLUTION
      imports CPP-DYNAMIC-SYNTAX
      imports CPP-SYMLOC-SYNTAX
      imports CPP-TYPE-MAP-SYNTAX
+     imports CPP-TYPING-SYNTAX
 
      rule (.K => resolveCPPReference(Base))
           ~> resolveCPPReferences((SetItem(Base::SymBase) => .Set) _::Set)
@@ -27,7 +28,7 @@ module LINKING-CPP-RESOLUTION
           <odr-decls>...
                OdrBase |-> (SetItem(odrDecl(Tu::String, QX::QualId, _, _, T::CPPType)) => .Set) _::Set
           ...</odr-decls>
-          <odr-defs>... QX |-> (T |-> _ _::TypeMap) ...</odr-defs>
+          <odr-defs>... QX |-> (stripType(T) |-> _ _::Map) ...</odr-defs>
 
      rule <k> resolveCPPReference(Base::SymBase) => .K ...</k>
           <odr-decls>...
@@ -38,20 +39,20 @@ module LINKING-CPP-RESOLUTION
           <odr-decls>...
                OdrBase |-> (SetItem(odrDecl(Tu::String, N:Namespace :: X::CId, _, _, T::CPPType)) => .Set) _::Set
           ...</odr-decls>
-          <odr-defs>... N :: X |-> (T |-> Base'::SymBase _::TypeMap) ...</odr-defs>
+          <odr-defs>... N :: X |-> (stripType(T) |-> (_, Base'::SymBase) _::Map) ...</odr-defs>
           <tu-id> Tu </tu-id>
           <ns-id> N </ns-id>
-          <nenv>... X |-> (T |-> envEntry(... base: Base::SymBase => Base') _::TypeMap) ...</nenv>
+          <nenv>... X |-> (stripType(T) |-> (_, envEntry(... base: Base::SymBase => Base')) _::Map) ...</nenv>
           <linkings>... .Map => Base |-> Base' ...</linkings>
 
      rule <k> resolveCPPReference(OdrBase::SymBase) ...</k>
           <odr-decls>...
                OdrBase |-> (SetItem(odrDecl(Tu::String, N:Namespace :: X::CId, _, _, T::CPPType)) => .Set) _::Set
           ...</odr-decls>
-          <odr-defs>... N :: X |-> (T |-> _ _::TypeMap) ...</odr-defs>
+          <odr-defs>... N :: X |-> (stripType(T) |-> _ _::Map) ...</odr-defs>
           <tu-id> Tu </tu-id>
           <ns-id> N </ns-id>
-          <nenv>... X |-> (T |-> envEntry(... base: Base:DirectBase) _::TypeMap) ...</nenv>
+          <nenv>... X |-> (stripType(T) |-> (_, envEntry(... base: Base:DirectBase)) _::Map) ...</nenv>
 
      rule <k> resolveCPPReference(OdrBase::SymBase) ...</k>
           <odr-decls>...
@@ -61,7 +62,7 @@ module LINKING-CPP-RESOLUTION
           <external-defs>... Mangled |-> Base':SymBase ...</external-defs>
           <tu-id> Tu </tu-id>
           <ns-id> N </ns-id>
-          <nenv>... X |-> (T |-> envEntry(... base: Base:LinkBase => Base') _::TypeMap) ...</nenv>
+          <nenv>... X |-> (stripType(T) |-> (_, envEntry(... base: Base:LinkBase => Base')) _::Map) ...</nenv>
           <linkings>... .Map => Base |-> Base' ...</linkings>
           requires notBool (N :: X, T in_keys(Defs))
 
@@ -72,7 +73,7 @@ module LINKING-CPP-RESOLUTION
           <external-defs>... Mangled |-> _ ...</external-defs>
           <tu-id> Tu </tu-id>
           <ns-id> N </ns-id>
-          <nenv>... X |-> (T |-> envEntry(... base: Base:DirectBase) _::TypeMap) ...</nenv>
+          <nenv>... X |-> (stripType(T) |-> (_, envEntry(... base: Base:DirectBase)) _::Map) ...</nenv>
 
      rule <k> (.K => ILL("TDR3",
                     "No definition for function or variable which was odr-used: "
@@ -102,7 +103,7 @@ module LINKING-CPP-RESOLUTION
      rule <k> resolveMain => .K ...</k>
           <main-tu>... (.Set => SetItem(MainTu)) </main-tu>
           (<linking-state>... .Bag ...</linking-state> => .Bag)
-          <odr-defs>... GlobalNamespace() :: Identifier("main") |-> (_::CPPType |-> obj(... d: static(MainTu:String))) ...</odr-defs>
+          <odr-defs>... GlobalNamespace() :: Identifier("main") |-> (_::CPPType |-> (_, obj(... d: static(MainTu:String)))) ...</odr-defs>
 
      // TODO(dwightguth): make this a better error message when we take the C++ semantics live
      // currently this error is both a C++ and a C error, since either C or C++ is allowed
@@ -123,19 +124,19 @@ module LINKING-CPP-RESOLUTION
           <odr-decls>...
                OdrBase |-> (SetItem(odrDecl(Tu::String, C:Class :: X::CId, _, _, T::CPPType)) => .Set) _::Set
           ...</odr-decls>
-          <odr-defs>... C :: X |-> (T |-> Base'::SymBase _::TypeMap) ...</odr-defs>
+          <odr-defs>... C :: X |-> (stripType(T) |-> (_, Base'::SymBase) _::Map) ...</odr-defs>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <cenv>... X |-> (T |-> envEntry(... base: (Base:LinkBase => Base')) _::TypeMap) ...</cenv>
+          <cenv>... X |-> (stripType(T) |-> (_, envEntry(... base: (Base:LinkBase => Base'))) _::Map) ...</cenv>
           <linkings>... .Map => Base |-> Base' ...</linkings>
 
      rule <k> resolveCPPReference(OdrBase::SymBase) ...</k>
           <odr-decls>...
                OdrBase |-> (SetItem(odrDecl(Tu::String, C:Class :: X::CId, _, _, T::CPPType)) => .Set) _::Set
           ...</odr-decls>
-          <odr-defs>... C :: X |-> (T |-> _ _::TypeMap) ...</odr-defs>
+          <odr-defs>... C :: X |-> (stripType(T) |-> _ _::Map) ...</odr-defs>
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
-          <cenv>... X |-> (T |-> envEntry(... base: Base:DirectBase) _::TypeMap) ...</cenv>
+          <cenv>... X |-> (stripType(T) |-> (_, envEntry(... base: Base:DirectBase)) _::Map) ...</cenv>
 
 endmodule

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -164,7 +164,7 @@ module LINKING-INIT
                   | #mergeDefs(Map, Map, Set) [function]
      rule mergeDefs(M1::Map, M2::Map) => #mergeDefs(M1, updateMap(M1, M2), intersectSet(keys(M1), keys(M2)))
      rule #mergeDefs(OldValues::Map, NewValues::Map, SetItem(Key:KItem) CommonKeys::Set)
-          => #mergeDefs(OldValues, NewValues[Key <- updateMap({{OldValues[Key] orDefault .Map::TypeMap}<:KItem}:>TypeMap, {{NewValues[Key] orDefault .Map::TypeMap}<:KItem}:>TypeMap)], CommonKeys)
+          => #mergeDefs(OldValues, NewValues[Key <- updateMap({{OldValues[Key] orDefault .Map::Map}<:KItem}:>Map, {{NewValues[Key] orDefault .Map::Map}<:KItem}:>Map)], CommonKeys)
      rule #mergeDefs(_, NewValues::Map, .Set) => NewValues
 
      // Allows definitions to be overridden in the Match extensions.


### PR DESCRIPTION
we utilize the ability to match map keys on function applications to bypass the need for this special logic.