### PR TITLE
BindReference in translation semantics

### DIFF
--- a/semantics/cpp/language/common/reference.k
+++ b/semantics/cpp/language/common/reference.k
@@ -1,9 +1,13 @@
 module CPP-REFERENCE-SYNTAX
      imports CPP-TYPING-SORTS
+     imports CPP-DYNAMIC-SORTS
 
      syntax Bool ::= isReferenceCompatible(CPPType, CPPType) [function]
                    | isReferenceRelated(CPPType, CPPType) [function]
                    | isValidReferenceType(CPPType) [function]
+
+     syntax ReferenceBindingResult ::= referenceBindingResult(Val)
+     syntax ValResult ::= ReferenceBindingResult
 
 endmodule
 

--- a/semantics/cpp/language/execution/expr/function-call.k
+++ b/semantics/cpp/language/execution/expr/function-call.k
@@ -14,6 +14,7 @@ module CPP-EXECUTION-EXPR-FUNCTION-CALL
      imports CPP-EXECUTION-ENV-SYNTAX
      imports CPP-MEMORY-ALLOC-SYNTAX
      imports CPP-MEMORY-READING-SYNTAX
+     imports CPP-REFERENCE-SYNTAX
      imports CPP-SYNTAX
      imports CPP-TYPE-MAP-SYNTAX
      imports CPP-TYPING-SYNTAX
@@ -164,6 +165,9 @@ module CPP-EXECUTION-EXPR-FUNCTION-CALL
      rule getBaseOfVal(lv(...v: L::SymLoc) #Or xv(...v: L::SymLoc) #Or prv(...v: L::SymLoc))
           => baseOfLoc(L)
 
+     rule getBaseOfVal(referenceBindingResult(V::Val))
+          => getBaseOfVal(V)
+
      syntax SymBase ::= baseOfLoc(SymLoc) [function]
 
      rule baseOfLoc(loc(Base::SymBase, _)) => Base
@@ -172,15 +176,7 @@ module CPP-EXECUTION-EXPR-FUNCTION-CALL
               => addToExecEnv(X, T, getBaseOfVal(V), false)
            ...</k>
           <curr-function-params>... .List => ListItem(X) </curr-function-params>
-          requires notBool isCPPRefType(T)
-               andBool X =/=K #NoName
-
-     rule <k> bindParam(X::CId, T::CPPType, V:Val) => declareNonStaticObjectExec(X, T,
-               bindReference(ExecName(NoNNS(), X), V),
-               Var(CopyInit()), AutoStorage, .Set) ...</k>
-          <curr-function-params>... .List => ListItem(X) </curr-function-params>
-          requires isCPPRefType(T)
-               andBool X =/=K #NoName
+          requires X =/=K #NoName
 
      rule bindParam(#NoName, T::CPPType, V:Val) => declareNonStaticObjectExec(#NoName, T, V,
                Var(CopyInit()), AutoStorage, .Set)

--- a/semantics/cpp/language/execution/expr/reference.k
+++ b/semantics/cpp/language/execution/expr/reference.k
@@ -20,7 +20,7 @@ module CPP-EXECUTION-EXPR-REFERENCE
 
      rule bindReference2(E1:LVal, E2::Expr)
           =>
-          bindReference3(E1, E2) ~> E1
+          bindReference3(E1, E2) ~> referenceBindingResult(E1)
 
      syntax KItem ::= bindReference3(LVal, Expr) [strict(2)]
 

--- a/semantics/cpp/language/execution/stmt/expr.k
+++ b/semantics/cpp/language/execution/stmt/expr.k
@@ -5,8 +5,10 @@ module CPP-EXECUTION-STMT-EXPR
      imports COMPAT-SYNTAX
      imports CPP-SYNTAX
      imports CPP-DYNAMIC-SYNTAX
+     imports CPP-REFERENCE-SYNTAX
 
      rule ExpressionStmt(V:Val) => fullExpression
-          requires Execution() andBool isEvalVal(V)
+          requires Execution() andBool
+          (isEvalVal(V) orBool referenceBindingResult(_) :=K V)
 
 endmodule

--- a/semantics/cpp/language/execution/stmt/return.k
+++ b/semantics/cpp/language/execution/stmt/return.k
@@ -15,6 +15,7 @@ module CPP-EXECUTION-STMT-RETURN
      imports CPP-DYNAMIC-SYNTAX
      imports CPP-EXECUTION-ENV-SYNTAX
      imports CPP-MEMORY-ALLOC-SYNTAX
+     imports CPP-REFERENCE-SYNTAX
      imports CPP-SYNTAX
      imports CPP-TYPING-SYNTAX
 
@@ -32,6 +33,8 @@ module CPP-EXECUTION-STMT-RETURN
      rule prepareReturn(t(... st: void) #as T::CPPType, V:PRVal) => Return''(V)
 
      syntax KItem ::= "Return'" "(" K "," CPPType ")" [strict(1)]
+
+     rule Return'(referenceBindingResult(V::Val) => V, _)
 
      // compute value category of result
      rule Return'(lv(Loc::SymLoc, Tr::Trace, T::CPPType), DeclT::CPPType) =>

--- a/semantics/cpp/language/translation/expr/function-call.k
+++ b/semantics/cpp/language/translation/expr/function-call.k
@@ -39,13 +39,6 @@ module CPP-TRANSLATION-EXPR-FUNCTION-CALL
 
      rule bindParams(ListItem(T:CPPType) P::List, ListItem(Init::Init) A::List, ListItem(_) DArgs::List)
           => ListItem(figureInit(le(temp(!I:Int, T), noTrace, T), T, Init, CopyInit())) bindParams(P, A, DArgs)
-          requires notBool (isCPPRefType(T) andBool isExpr(Init))
-
-     // in this case we are calling bindReference instead of the regular initialization scenario, but
-     // bindReference shouldn't be executed in the calling context, it needs to be executed only in the
-     // called function, otherwise we will end up with an lvalue where the parameter should be an xvalue.
-     rule bindParams(ListItem(cppRefType #as T::CPPType) P::List, ListItem(Init:Expr) A::List, ListItem(_) DArgs::List)
-          => ListItem(Init) bindParams(P, A, DArgs)
 
      // ignore implicit object parameter for static function member
      rule bindParams(ListItem(implicitObjectParameter(t(... st: no-type))) P::List,


### PR DESCRIPTION
Refactorings that will enable us to move parts of `bindReference` computations (temporary materialization for now and conversions in future) from execution semantics to translation semantics. Mainly removes a call to `bindReference` from execution semantics.