### PR TITLE
Remove `apt-get upgrade` from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN update-locale
 # Install packages. #
 #####################
 
-RUN apt-get upgrade --yes -qq \
+RUN apt-get update -qq \
     \
     && apt install --yes                                                             \
         bison build-essential clang++-6.0 clang-6.0 cmake coreutils curl diffutils   \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/jav
 # Set up a default user. #
 ##########################
 
-RUN apt-get install --yes sudo
+RUN apt-get update -qq \
+    && apt-get install --yes sudo
 
 ARG UID=1000
 ARG GID=1000


### PR DESCRIPTION
I think it's bad practice (https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) and possibly causing cacheing issues.

