### PR TITLE
Finish fixing C semantics for llvm backend to kompile

### DIFF
--- a/parser/kPrinter.ml
+++ b/parser/kPrinter.ml
@@ -29,7 +29,7 @@ let init_state : printer_state =
 type csort =
   | K | KItem | KResult | Bool | Int | Float | String
   | Specifier | Qualifier | FunctionSpecifier | StorageClassSpecifier | SpecifierElem
-  | AutoSpecifier | TypeSpecifier | CabsLoc | CId | Init | RValue | StrictList
+  | AutoSpecifier | TypeSpecifier | CabsLoc | CId | NoInit | RValue | StrictList
   | Constant | StringLiteral | FloatConstant | IntConstant
 
 let csort_to_string : csort -> string = function
@@ -49,7 +49,7 @@ let csort_to_string : csort -> string = function
   | TypeSpecifier         -> "TypeSpecifier"
   | CabsLoc               -> "CabsLoc"
   | CId                   -> "CId"
-  | Init                  -> "Init"
+  | NoInit                -> "NoInit"
   | RValue                -> "RValue"
   | StrictList            -> "StrictList"
   | Constant              -> "Constant"
@@ -345,7 +345,7 @@ and specifier a = kapply Specifier "Specifier" [list_of specifier_elem a KItem]
 and name (a, b, c, d) = kapply KItem "Name" [identifier a CId; decl_type b KItem; list_of specifier_elem c KItem]
 and single_name (a, b) = kapply KItem "SingleName" [specifier a KItem; name b KItem]
 and init_expression = function
-  | NO_INIT         -> kapply0 Init "NoInit"
+  | NO_INIT         -> kapply0 NoInit "NoInit"
   | SINGLE_INIT exp -> kapply KItem "SingleInit" [expression exp KItem]
   | COMPOUND_INIT a -> kapply KItem "CompoundInit" [list_of init_fragment a KItem]
 and init_fragment (a, b) =

--- a/semantics/c/language/common/dynamic.k
+++ b/semantics/c/language/common/dynamic.k
@@ -240,7 +240,7 @@ module C-DYNAMIC
      syntax SSList ::= KItem "seqstrict::" SSList [seqstrict]
                      | ".SSList"
      rule isKResult(.SSList) => true
-     rule isKResult(S1::SSList seqstrict:: S2::SSList) => isKResult(S1) andBool isKResult(S2)
+     rule isKResult(S1::KItem seqstrict:: S2::SSList) => isKResult(S1) andBool isKResult(S2)
      rule toSSList(ListItem(K:KItem) L::List) => K seqstrict:: toSSList(L)
      rule toSSList(.List) => .SSList
      rule ofSSList(krlist(L1::List) seqstrict:: L2::SSList) => L1 ofSSList(L2)
@@ -254,7 +254,7 @@ module C-DYNAMIC
      syntax SList ::= KItem "strict::" SList [strict]
                     | ".SList"
      rule isKResult(.SList) => true
-     rule isKResult(S1::SList strict:: S2::SList) => isKResult(S1) andBool isKResult(S2)
+     rule isKResult(S1::KItem strict:: S2::SList) => isKResult(S1) andBool isKResult(S2)
      rule toSList(ListItem(K:KItem) L::List) => K strict:: toSList(L)
      rule toSList(.List) => .SList
      rule ofSList(krlist(L1::List) strict:: L2::SList) => L1 ofSList(L2)

--- a/semantics/c/language/common/dynamic.k
+++ b/semantics/c/language/common/dynamic.k
@@ -134,8 +134,8 @@ module C-DYNAMIC-SYNTAX
 
      // Initializers.
      syntax InitLValue ::= LValue
-                         | InitLValue "[" "[" Int "]" "]" [strict(1)]
-                         | InitLValue ".init" CId [strict(1)]
+                         | KItem "[" "[" Int "]" "]" [strict(1)]
+                         | KItem ".init" CId [strict(1)]
 
      syntax EncodableValue ::= Opaque
      syntax Opaque ::= opaque(K, UType)

--- a/semantics/c/language/common/dynamic.k
+++ b/semantics/c/language/common/dynamic.k
@@ -93,7 +93,8 @@ module C-DYNAMIC-SYNTAX
      syntax KItem ::= "comma"
      // these are semantic
 
-     syntax NoInit ::= initValue(CId, Type, K)
+     syntax KResult ::= initValue(CId, Type, K)
+     syntax NoInit
      syntax KResult ::= NoInit
 
      syntax CompoundLiteralId ::= compoundLiteral(Int)
@@ -207,6 +208,8 @@ module C-DYNAMIC
 
      rule N:Int => tv(N, utype(cfg:largestUnsigned))
           [structural] // for internal computations
+
+     rule isNoInit(initValue(_, _, .K)) => true
 
      rule fillRHoles(V:RValue, te(L:K := E:K, T::UType)) => te(L := fillRHoles(V, E), T)
      rule fillRHoles(V:RValue, Cast(T::Type, E:K)) => Cast(T, fillRHoles(V, E))

--- a/semantics/c/language/common/dynamic.k
+++ b/semantics/c/language/common/dynamic.k
@@ -93,8 +93,7 @@ module C-DYNAMIC-SYNTAX
      syntax KItem ::= "comma"
      // these are semantic
 
-     syntax KResult ::= initValue(CId, Type, K)
-     syntax NoInit
+     syntax NoInit ::= initValue(CId, Type, K)
      syntax KResult ::= NoInit
 
      syntax CompoundLiteralId ::= compoundLiteral(Int)
@@ -208,10 +207,6 @@ module C-DYNAMIC
 
      rule N:Int => tv(N, utype(cfg:largestUnsigned))
           [structural] // for internal computations
-
-     rule isNoInit(NoInit()) => true
-     rule isNoInit(initValue(_, _, .K)) => true
-     rule isNoInit(_) => false [owise]
 
      rule fillRHoles(V:RValue, te(L:K := E:K, T::UType)) => te(L := fillRHoles(V, E), T)
      rule fillRHoles(V:RValue, Cast(T::Type, E:K)) => Cast(T, fillRHoles(V, E))

--- a/semantics/c/language/execution/configuration.k
+++ b/semantics/c/language/execution/configuration.k
@@ -14,6 +14,8 @@ module C-CONFIGURATION
      imports SYMLOC-SYNTAX
      imports COMMON-THREAD-LOCAL
 
+     syntax GeneratedTopCell
+
      configuration
 <global />
 <s />
@@ -36,7 +38,7 @@ module C-CONFIGURATION
                <thread-id color="yellow"> 0 </thread-id>
 
                <k color="green" multiplicity="?">
-                    loadObj(unwrapObj($PGM:K))
+                    loadObj(unwrapObj($PGM:GeneratedTopCell))
                     ~> initMainThread(getEntryPoint($OPTIONS:Set))
                     ~> pgmArgs($ARGV:List)
                     ~> callEntryPoint(getEntryPoint($OPTIONS:Set), size($ARGV:List), incomingArguments($ARGV:List))

--- a/semantics/c/language/execution/init.k
+++ b/semantics/c/language/execution/init.k
@@ -40,7 +40,7 @@ module C-EXECUTION-INIT
      imports LIBC-IO-SYNTAX
      imports LIBCPP-BOOTSTRAP-SYNTAX
 
-     syntax TCell ::= ".TCell" [klabel(.TCell)]
+     syntax TCell ::= ".TCell" [klabel(.TCell), symbol]
 
      /*@ \fromStandard{\source[n1570]{\para{5.1.2.2.1}{2}}}{
      If they are declared, the parameters to the main function shall obey the

--- a/semantics/c/language/execution/io.k
+++ b/semantics/c/language/execution/io.k
@@ -129,11 +129,11 @@ module C-IO
           ...</buffer>
           <mem> M::Map => bufferFill(M, base(Loc), M[base(Loc)], offset(Loc), N, V) </mem>
           requires notBool isNativeLoc(Loc)
-          [structural, priority(40)]
+          [structural, priority(80)]
      rule <buffer>
                ListItem(bfill(Loc::SymLoc, N::Int, V::Bits)) => #fillNativeBytes(Loc, N, V)
           ...</buffer>
-          requires isNativeLoc(Loc) [priority(40)]
+          requires isNativeLoc(Loc) [priority(80)]
 
      syntax Map ::= bufferFill(Map, SymBase, K, Int, Int, Bits) [function]
      rule bufferFill(M::Map, Base::SymBase, object(T::EffectiveType, Len::Int, Bytes::Array), Offset::Int, N::Int, V::Bits)

--- a/semantics/c/language/execution/stmt/switch.k
+++ b/semantics/c/language/execution/stmt/switch.k
@@ -80,7 +80,7 @@ module C-STMT-SWITCH
           requires SN =/=Int SN'
           [structural]
 
-     rule #handleSwitch-aux(_:Int, _:RValue, X::CId => nextCaseLabel, _)
+     rule #handleSwitch-aux(_:Int, _:RValue, X:K => nextCaseLabel, _)
           requires caseLabel(...) :/=K X
                andBool X =/=K nextCaseLabel
           [structural]

--- a/semantics/c/language/translation/decl/initializer.k
+++ b/semantics/c/language/translation/decl/initializer.k
@@ -186,7 +186,7 @@ module C-DECL-INITIALIZER
      syntax SubObjectControl ::= "next" | "down" | "block"
 
      syntax KItem ::= "subobjectKCell"
-     rule subobjectKCell => fillInit(?_) #Or fillInit-aux(?_) #Or t(?_, ?_, ?_) [macro]
+     rule subobjectKCell => fillInit(?_) #Or fillInit-aux(?_) #Or initializeSingleInit2(?_, ?_) [macro]
 
      syntax Bool ::= isInFieldInit(KItem) [function]
      rule isInFieldInit(fillInit(InitFragment(InFieldInit(_, _), _))) => true
@@ -429,13 +429,14 @@ module C-DECL-INITIALIZER
      rule trapPadding(_:LValue) => .K
 
      syntax KItem ::= initializeSingleInit(KItem) [strict]
+                    | initializeSingleInit2(Type, KItem)
 
      rule (.K => typeof(K)) ~> initializeSingleInit(K:KResult)
           [structural]
-     rule (typeof(T:Type) => T) ~> initializeSingleInit(_)
+     rule typeof(T:Type) ~> initializeSingleInit(K:KItem) => initializeSingleInit2(T, K)
           [structural]
 
-     rule <k> T':Type ~> initializeSingleInit(K':KResult) => .K ...</k>
+     rule <k> initializeSingleInit2(T'::Type, K':KResult) => .K ...</k>
           <curr-subobject>
                (.List => ListItem(next)) ListItem(ncle(K:KItem, T::Type))
           ...</curr-subobject>
@@ -448,7 +449,7 @@ module C-DECL-INITIALIZER
           requires notBool isAggregateOrUnionType(T)
                andBool notBool isStructOrUnionType(T')
           [structural]
-     rule <k> T':Type ~> initializeSingleInit(_) ...</k>
+     rule <k> initializeSingleInit2(T'::Type, _) ...</k>
           <curr-subobject>
                (.List => ListItem(down)) ListItem(ncle(K:K, T::Type))
           ...</curr-subobject>
@@ -456,7 +457,7 @@ module C-DECL-INITIALIZER
                andBool notBool isAggregateOrUnionType(T')
           [structural]
      syntax KItem ::= initFromAggregateRHS(K, Type)
-     rule structOrUnionType #as T:Type ~> initializeSingleInit(K:KResult)
+     rule initializeSingleInit2(structOrUnionType #as T::Type, K:KResult)
           => initFromAggregateRHS(K, T)
           [structural]
 

--- a/semantics/c/language/translation/expr/members.k
+++ b/semantics/c/language/translation/expr/members.k
@@ -14,7 +14,7 @@ module C-EXPR-MEMBERS
 
      rule te(K:KItem, structOrUnionUType #as T::UType) . F:CId => te(K . F, rvalType(findFieldType(F, type(T))))
 
-     rule ncle(K::InitLValue, t(... st: _:SimpleArrayType) #as T::Type) [[ N::Int ]]
+     rule ncle(K:KItem, t(... st: _:SimpleArrayType) #as T::Type) [[ N::Int ]]
           => le(K [[ N ]], addQualifiers(getQualifiers(T), getElementType(N, T)))
 
 endmodule

--- a/semantics/common/execution/io-buffered.k
+++ b/semantics/common/execution/io-buffered.k
@@ -25,15 +25,15 @@ module COMMON-IO-BUFFERED
           ...</buffer>
           <mem> M::Map => bufferWrite(M, Base, M[Base], Offset, L) </mem>
           requires notBool isNativeLoc(loc(Base, Offset))
-          [structural, priority(40)]
+          [structural, priority(80)]
      rule <buffer>
                ListItem(bwrite((Loc::SymLoc => Loc +bytes 1), ((ListItem(V:KItem) => writeNativeByte(Loc, V)) _::List)))
           ...</buffer>
-          requires isNativeLoc(Loc) [priority(40)]
+          requires isNativeLoc(Loc) [priority(80)]
      rule <buffer>
                ListItem(bwrite(Loc::SymLoc, .List)) => .List
           ...</buffer>
-          requires isNativeLoc(Loc) [priority(40)]
+          requires isNativeLoc(Loc) [priority(80)]
 
      rule locations(.List) => .Set
      rule locations(ListItem(bwrite(Loc::SymLoc, Bytes::List)) L::List)

--- a/semantics/common/init.k
+++ b/semantics/common/init.k
@@ -4,7 +4,7 @@ module COMMON-INIT-SYNTAX
 
      syntax KItem ::= loadObj(K)
      // this takes input from a file which is not split by thread, so we don't want to split this rule.
-     syntax K ::= unwrapObj(K) [function, noThread]
+     syntax KItem ::= unwrapObj(GeneratedTopCell) [function, noThread, symbol]
 
      syntax CId ::= "mainArguments"
 
@@ -31,8 +31,6 @@ module COMMON-INIT
                <global> G::Bag </global>
           ...</generatedTop>)
           => <global> G </global>
-
-     rule unwrapObj(.K) => .K
 
      rule <k> removeUnusedIdentifiers(Tu::String) => removeFromExternalDecls(Set2List(keys(Env) -Set Uses), Tu) ...</k>
           <tu-id> Tu </tu-id>

--- a/semantics/common/options.k
+++ b/semantics/common/options.k
@@ -1,8 +1,5 @@
 module OPTIONS-SORTS
      syntax Opt
-     syntax TransOpt
-     syntax ExecOpt
-     syntax Opt ::= TransOpt | ExecOpt
 endmodule
 
 module OPTIONS-SYNTAX
@@ -10,18 +7,16 @@ module OPTIONS-SYNTAX
      imports INT
      imports STRING
 
-     syntax TransOpt ::= Debug() [symbol]
-                       | Link() [symbol]                         // Resolve uses to definitions.
-                       | NoNativeFallback() [symbol]             // Don't attempt linking with native defs.
-
-     syntax ExecOpt ::= EntryPoint(String) [symbol]              // Set the program entry point symbol.
-                      | NoIO() [symbol]                          // Disable IO.
-                      | UseNativeStdLib() [symbol]               // Prefer the native standard library
-                      | Stack(Int) [symbol] | Heap(Int) [symbol] // Stack/heap bounds checking.
-                      | Breakpoint(String, Int) [symbol]         // Set a breakpoint at a certain file/line.
-                      | ActiveBreakpoint(String, Int) [symbol]   // Flags the active breakpoint.
-
-     syntax Opt ::= RecoverAll() [symbol]                        // Attempt recovery on all errors.
+     syntax Opt ::= Debug() [symbol]
+                  | Link() [symbol]                         // Resolve uses to definitions.
+                  | NoNativeFallback() [symbol]             // Don't attempt linking with native defs.
+                  | EntryPoint(String) [symbol]              // Set the program entry point symbol.
+                  | NoIO() [symbol]                          // Disable IO.
+                  | UseNativeStdLib() [symbol]               // Prefer the native standard library
+                  | Stack(Int) [symbol] | Heap(Int) [symbol] // Stack/heap bounds checking.
+                  | Breakpoint(String, Int) [symbol]         // Set a breakpoint at a certain file/line.
+                  | ActiveBreakpoint(String, Int) [symbol]   // Flags the active breakpoint.
+                  | RecoverAll() [symbol]                        // Attempt recovery on all errors.
                   | InteractiveFail() [symbol]                   // Enter interactive mode when recovery fails.
                   | FatalErrors() [symbol]                       // Don't attempt any error recovery.
                   | Lint() [symbol]                              // Enable extra warnings.

--- a/semantics/common/options.k
+++ b/semantics/common/options.k
@@ -10,21 +10,21 @@ module OPTIONS-SYNTAX
      imports INT
      imports STRING
 
-     syntax TransOpt ::= Debug()
-                       | Link()                       // Resolve uses to definitions.
-                       | NoNativeFallback()           // Don't attempt linking with native defs.
+     syntax TransOpt ::= Debug() [symbol]
+                       | Link() [symbol]                         // Resolve uses to definitions.
+                       | NoNativeFallback() [symbol]             // Don't attempt linking with native defs.
 
-     syntax ExecOpt ::= EntryPoint(String)            // Set the program entry point symbol.
-                      | NoIO()                        // Disable IO.
-                      | UseNativeStdLib()             // Prefer the native standard library
-                      | Stack(Int) | Heap(Int)        // Stack/heap bounds checking.
-                      | Breakpoint(String, Int)       // Set a breakpoint at a certain file/line.
-                      | ActiveBreakpoint(String, Int) // Flags the active breakpoint.
+     syntax ExecOpt ::= EntryPoint(String) [symbol]              // Set the program entry point symbol.
+                      | NoIO() [symbol]                          // Disable IO.
+                      | UseNativeStdLib() [symbol]               // Prefer the native standard library
+                      | Stack(Int) [symbol] | Heap(Int) [symbol] // Stack/heap bounds checking.
+                      | Breakpoint(String, Int) [symbol]         // Set a breakpoint at a certain file/line.
+                      | ActiveBreakpoint(String, Int) [symbol]   // Flags the active breakpoint.
 
-     syntax Opt ::= RecoverAll()                      // Attempt recovery on all errors.
-                  | InteractiveFail()                 // Enter interactive mode when recovery fails.
-                  | FatalErrors()                     // Don't attempt any error recovery.
-                  | Lint()                            // Enable extra warnings.
+     syntax Opt ::= RecoverAll() [symbol]                        // Attempt recovery on all errors.
+                  | InteractiveFail() [symbol]                   // Enter interactive mode when recovery fails.
+                  | FatalErrors() [symbol]                       // Don't attempt any error recovery.
+                  | Lint() [symbol]                              // Enable extra warnings.
 
      syntax String ::= showOpt(Opt) [function]
 

--- a/semantics/common/syntax.k
+++ b/semantics/common/syntax.k
@@ -63,7 +63,8 @@ module COMMON-SYNTAX
      syntax Location ::= CodeLoc(K, CabsLoc)
 
      syntax FunctionSpecifier ::= Inline() [symbol]
-     syntax Init ::= NoInit() [symbol]
+     syntax NoInit ::= NoInit() [symbol]
+     syntax Init ::= NoInit
 
      syntax AutoSpecifier ::= Auto() [symbol]
      syntax StorageClassSpecifier ::= Static() [symbol] | Extern() [symbol] | Register() [symbol] | ThreadLocal() [symbol]

--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -661,7 +661,7 @@ module CPP-DYNAMIC-OTHER
 
      rule isKResult(.SPRValList) => true
 
-     rule isKResult(S1::SPRValList prval:: S2::SPRValList) => isKResult(S1) andBool isKResult(S2)
+     rule isKResult(S1:K prval:: S2::SPRValList) => isKResult(S1) andBool isKResult(S2)
 
      rule toSPRValList(ListItem(K:KItem) L::List) => K prval:: toSPRValList(L)
 
@@ -695,7 +695,7 @@ module CPP-DYNAMIC-OTHER
 
      rule isKResult(.STypeStrictList) => true
 
-     rule isKResult(S1::STypeStrictList typeStrict:: S2::STypeStrictList) => isKResult(S1) andBool isKResult(S2)
+     rule isKResult(S1:K typeStrict:: S2::STypeStrictList) => isKResult(S1) andBool isKResult(S2)
 
      rule toSTypeStrictList(ListItem(K:KItem) L::List) => K typeStrict:: toSTypeStrictList(L)
 
@@ -723,7 +723,7 @@ module CPP-DYNAMIC-OTHER
      syntax SSList ::= KItem "seqstrict::" SSList [klabel(seqstrictlist-sep-cpp), seqstrict(c)]
                      | ".SSList" [klabel(seqstrictlist-unit-cpp)]
      rule isKResult(.SSList) => true
-     rule isKResult(S1::SSList seqstrict:: S2::SSList) => isKResult(S1) andBool isKResult(S2)
+     rule isKResult(S1::KItem seqstrict:: S2::SSList) => isKResult(S1) andBool isKResult(S2)
      rule isExecResult(.SSList) => true
      rule isExecResult(S1::SSList seqstrict:: S2::SSList) => isExecResult(S1) andBool isExecResult(S2)
      rule toSSList(ListItem(K:KItem) L::List) => K seqstrict:: toSSList(L)
@@ -742,7 +742,7 @@ module CPP-DYNAMIC-OTHER
      syntax SList ::= KItem "strict::" SList [klabel(strictlist-sep-cpp), strict(c)]
                     | ".SList" [klabel(strictlist-unit-cpp)]
      rule isKResult(.SList) => true
-     rule isKResult(S1::SList strict:: S2::SList) => isKResult(S1) andBool isKResult(S2)
+     rule isKResult(S1::KItem strict:: S2::SList) => isKResult(S1) andBool isKResult(S2)
      rule isExecResult(.SList) => true
      rule isExecResult(S1::SList strict:: S2::SList) => isExecResult(S1) andBool isExecResult(S2)
      rule toSList(ListItem(K:KItem) L::List) => K strict:: toSList(L)

--- a/semantics/cpp/language/translation/decl/declarator.k
+++ b/semantics/cpp/language/translation/decl/declarator.k
@@ -56,7 +56,7 @@ module CPP-TRANSLATION-DECL-DECLARATOR
      rule FunctionDecl(N::NNSVal, X::CId, Mangled::CId, T::CPPType, Params::List)
           => NormalizedDecl(N, X, Mangled, T, NoInit(), Function(Params)) [anywhere]
 
-     rule VarDecl(N::NNSVal, X::CId, Mangled::CId, T::CPPType, Init::Expr, IsDirect:Bool)
+     rule VarDecl(N::NNSVal, X::CId, Mangled::CId, T::CPPType, Init::Init, IsDirect:Bool)
           => NormalizedDecl(N, X, Mangled, T, Init, Var(#if IsDirect #then DirectInit() #else CopyInit() #fi)) [anywhere]
 
      rule FunctionDefinition(N::NNSVal, X::CId, Mangled::CId, T::CPPType, Params::List, Body::Stmt)
@@ -837,6 +837,6 @@ module CPP-TRANSLATION-DECL-DECLARATOR
 
      rule #emptyDefaultArguments(N::Int => N -Int 1,
             defArgs(krlist(_::List (.List => ListItem(NoArg()))),
-                    krlist(_::List (.List => ListItem(NoInitCat()))),
-                    krlist(_::List (.List => ListItem(NoInitType()))))) [owise]
+                    krlist(_::List (.List => ListItem(NoInitType()))),
+                    krlist(_::List (.List => ListItem(NoInitCat()))))) [owise]
 endmodule

--- a/semantics/cpp/language/translation/env.k
+++ b/semantics/cpp/language/translation/env.k
@@ -139,24 +139,24 @@ module CPP-TRANSLATION-ENV
             defArgs(krlist((ListItem(_) => .List) _),
                     krlist((ListItem(_) => .List) _),
                     krlist((ListItem(_) => .List) _)),
-            defArgs(krlist((ListItem(I::Init) => .List) _),
-                    krlist((ListItem(C::ValueCategory) => .List) _),
-                    krlist((ListItem(T::CPPDType) => .List) _)),
-            defArgs(krlist(_::List (.List => ListItem(I::Init))),
-                    krlist(_::List (.List => ListItem(C::ValueCategory))),
-                    krlist(_::List (.List => ListItem(T::CPPDType)))))
+            defArgs(krlist((ListItem(I:KItem) => .List) _),
+                    krlist((ListItem(T::CPPDType) => .List) _),
+                    krlist((ListItem(C::ValueCategory) => .List) _)),
+            defArgs(krlist(_::List (.List => ListItem(I:KItem))),
+                    krlist(_::List (.List => ListItem(T::CPPDType))),
+                    krlist(_::List (.List => ListItem(C::ValueCategory)))))
           requires I =/=K NoArg()
 
      rule #updateDefaultArgs(
-            defArgs(krlist((ListItem(I::Init) => .List) _),
-                    krlist((ListItem(C::ValueCategory) => .List) _),
-                    krlist((ListItem(T::CPPDType) => .List) _)),
+            defArgs(krlist((ListItem(I:KItem) => .List) _),
+                    krlist((ListItem(T::CPPDType) => .List) _),
+                    krlist((ListItem(C::ValueCategory) => .List) _)),
             defArgs(krlist((ListItem(NoArg()) => .List) _),
                     krlist((ListItem(_) => .List) _),
                     krlist((ListItem(_) => .List) _)),
-            defArgs(krlist(_::List (.List => ListItem(I::Init))),
-                    krlist(_::List (.List => ListItem(C::ValueCategory))),
-                    krlist(_::List (.List => ListItem(T::CPPDType)))))
+            defArgs(krlist(_::List (.List => ListItem(I:KItem))),
+                    krlist(_::List (.List => ListItem(T::CPPDType))),
+                    krlist(_::List (.List => ListItem(C::ValueCategory)))))
 
      rule #updateDefaultArgs(
             defArgs(krlist(.List), krlist(.List), krlist(.List)),

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -1,7 +1,7 @@
 module LINKING-INIT-SYNTAX
      imports BASIC-K
 
-     syntax KItem ::= load(K)
+     syntax KItem ::= load(K) [symbol]
      syntax KItem ::= "link"
 
 endmodule


### PR DESCRIPTION
With this PR, the C semantics should kompile on the LLVM backend and pass the smoke test. Changes to make it actually use the llvm backend will come separately at a later date, and currently exist on a branch.