### PR TITLE
Disambiguate some cpp klabels.

### DIFF
--- a/profiles/x86-gcc-limited-libc/semantics/c-settings.k
+++ b/profiles/x86-gcc-limited-libc/semantics/c-settings.k
@@ -79,7 +79,7 @@ module C-SETTINGS
 
      rule cfg:stackSize(_, _) => 0
 
-     rule cfg:reservedKeywordSupported(_) => false
+     rule cfg:reservedKeywordSupported(_) => true
 
      // Error Recovery
      rule HALT ~> _:Error => .K

--- a/semantics/c/language/common/dynamic.k
+++ b/semantics/c/language/common/dynamic.k
@@ -32,6 +32,7 @@ module C-DYNAMIC-SYNTAX
      imports C-DYNAMIC-SORTS
      imports C-REVAL-SYNTAX
      imports C-TYPING-SORTS
+     imports COMPAT-SORTS
      imports SYMLOC-SORTS
 
      syntax Agg ::= agg(List)
@@ -142,6 +143,13 @@ module C-DYNAMIC-SYNTAX
      syntax K ::= fromOpaque(CValue) [function]
 
      syntax KItem ::= "defaultCase"
+
+     syntax SSList ::= toSSList(List) [function]
+     syntax List ::= ofSSList(SSList) [function]
+     syntax SList ::= toSList(List) [function]
+     syntax List ::= ofSList(SList) [function]
+
+     syntax KItem ::= seqstrict(StrictList)
 
 endmodule
 

--- a/semantics/c/language/common/syntax.k
+++ b/semantics/c/language/common/syntax.k
@@ -1,7 +1,6 @@
 module C-SORTS
      syntax StorageClassSpecifier
      syntax Qualifier
-     syntax Modifier ::= Qualifier
      syntax Modifier ::= StorageClassSpecifier
 endmodule
 

--- a/semantics/c/language/translation/typing/canonicalization.k
+++ b/semantics/c/language/translation/typing/canonicalization.k
@@ -3,7 +3,8 @@ module C-TYPING-CANONICALIZATION-SYNTAX
      syntax KItem ::= canonicalizeType(List)
      syntax KItem ::= "canonicalizeType'" "(" List "," List "," List ")"
      syntax KItem ::= canonicalizeSpecifier(List)
-     syntax Bool ::= isReducibleSpecifier(K) [function]
+     syntax Bool ::= isReducibleSpecifier(KItem) [function]
+     syntax Bool ::= isReducibleModifier(KItem) [function]
      syntax KItem ::= addMods(List, KItem) [strict(2)]
 endmodule
 
@@ -31,45 +32,36 @@ module C-TYPING-CANONICALIZATION
 
      rule canonicalizeType(M::List) => canonicalizeType'(M, .List, .List)
           [structural]
-     // Sort specifiers from modifiers.
+
+     // Sort type specifiers from modifiers/qualifiers.
      rule canonicalizeType'(_::List (ListItem(S:TypeSpecifier) => .List),
                _::List (.List => ListItem(S)),
                _)
+          requires notBool isReducibleSpecifier(S)
           [structural]
-     rule canonicalizeType'(_::List (ListItem(M:Modifier) => .List),
-               _,
-               _::List (.List => ListItem(M)))
+     rule canonicalizeType'((.List => Attrs) _::List ListItem(EnumDef(_, _, list(Attrs::List => .List))), _, _)
+          requires Attrs =/=K .List
           [structural]
-     rule canonicalizeType'(_::List (ListItem(S:KItem) => .List),
-               _,
-               _)
-          requires notBool isModifier(S)
-               andBool notBool isTypeSpecifier(S)
-               andBool notBool isReducibleSpecifier(S)
+     rule canonicalizeType'((.List => Attrs) _::List ListItem(EnumRef(_, list(Attrs::List) => .K)), _, _)
           [structural]
-     rule (.K => DeclType(S, D))
-          ~> canonicalizeType'(_ ListItem(TAtomic(S:KItem, D:KItem)), _, _)
+     rule canonicalizeType'((.List => Attrs) _::List ListItem(StructDef(_, _, list(Attrs::List => .List))), _, _)
+          requires Attrs =/=K .List
           [structural]
-     rule (T:Type => .K)
-          ~> canonicalizeType'(_::List (ListItem(TAtomic(_, _)) => .List),
-               _,
-               _::List (.List => ListItem(atomic(T))))
+     rule canonicalizeType'((.List => Attrs) _::List ListItem(StructRef(_, list(Attrs::List) => .K)), _, _)
           [structural]
-     rule (.K => DeclType(S, D))
-          ~> canonicalizeType'(_ ListItem(AlignasType(S:KItem, D:KItem)), _, _)
+     rule canonicalizeType'((.List => Attrs) _::List ListItem(UnionDef(_, _, list(Attrs::List => .List))), _, _)
+          requires Attrs =/=K .List
           [structural]
-     rule (T:Type => .K)
-          ~> canonicalizeType'(_::List (ListItem(AlignasType(_, _)) => .List),
-               _,
-               _::List (.List => ListItem(alignas(byteAlignofType(T)))))
-          [structural]
-     context canonicalizeType'(_ ListItem(AlignasExpression(HOLE:KItem)), _, _)
-     rule canonicalizeType'(_::List (ListItem(AlignasExpression(tv(A:Int, _))) => .List),
-               _,
-               _::List (.List => ListItem(alignas(A))))
+     rule canonicalizeType'((.List => Attrs) _::List ListItem(UnionRef(_, list(Attrs::List) => .K)), _, _)
           [structural]
      rule (.K => CV("TCANON3", "Function declared without a return type."))
           ~> canonicalizeType'(_::List ListItem(MissingType()), _, _)
+          [structural]
+     rule canonicalizeType'(_::List (ListItem(S::KItem) => .List),
+               _,
+               _::List (.List => ListItem(S)))
+          requires notBool isTypeSpecifier(S)
+               andBool notBool isReducibleSpecifier(S)
           [structural]
      // Canonicalize the specifiers then add the modifiers.
      rule canonicalizeType'(.List, Specs::List, Mods::List)
@@ -77,40 +69,65 @@ module C-TYPING-CANONICALIZATION
           [structural]
 
      // Done like this to ignore unsupported attributes.
-     rule isReducibleSpecifier(TAtomic(_, _)) => true
-     rule isReducibleSpecifier(AlignasExpression(_)) => true
-     rule isReducibleSpecifier(AlignasType(_, _)) => true
+     rule isReducibleSpecifier(EnumDef(_, _, list(ListItem(_) _::List))) => true
+     rule isReducibleSpecifier(EnumRef(_, list(_))) => true
+     rule isReducibleSpecifier(StructDef(_, _, list(ListItem(_) _::List))) => true
+     rule isReducibleSpecifier(StructRef(_, list(_))) => true
+     rule isReducibleSpecifier(UnionDef(_, _, list(ListItem(_) _::List))) => true
+     rule isReducibleSpecifier(UnionRef(_, list(_))) => true
      rule isReducibleSpecifier(MissingType()) => true
      rule isReducibleSpecifier(_) => false [owise]
+
+     rule isReducibleModifier(TAtomic(_, _)) => true
+     rule isReducibleModifier(AlignasExpression(_)) => true
+     rule isReducibleModifier(AlignasType(_, _)) => true
+     rule isReducibleModifier(_) => false [owise]
 
      rule addMods(Mods::List ListItem(RestrictReserved(Tok:String, _)), T:Type)
           => addMods(Mods, addQualifier(Restrict(), T))
           requires cfg:reservedKeywordSupported(Tok)
           [structural]
-     rule addMods(Mods::List ListItem(RestrictReserved(Tok::String, Loc::CabsLoc)), T:Type)
-          => SE("TCANON2","Unsupported reserved identifier "+String Tok +String " (reserved variant of restrict).")
+     rule (.K => SE("TCANON2","Unsupported reserved identifier "+String Tok +String " (reserved variant of restrict)."))
+          ~> addMods(Mods::List ListItem(RestrictReserved(Tok::String, Loc::CabsLoc)), T:Type)
           requires notBool cfg:reservedKeywordSupported(Tok)
           [structural]
      rule addMods(Mods::List ListItem(Q:Qualifier), T:Type)
           => addMods(Mods, addQualifier(Q, T))
           requires RestrictReserved(...) :/=K Q
+               andBool notBool isReducibleModifier(Q)
           [structural]
      rule addMods(Mods::List ListItem(M:Modifier), T:Type)
           => addMods(Mods, addModifier(M, T))
-          requires notBool isQualifier(M)
-          [structural]
-     rule addMods(Mods::List (ListItem(S:KItem) => .List), _:KResult)
-          requires notBool isModifier(S)
-               andBool notBool isReducibleSpecifier(S)
-          [structural]
-     rule addMods(.List, T:Type) => T
-          requires notBool isCompleteType(T)
-               orBool getAlignas(T) >=Int byteAlignofType(T)
+          requires notBool isReducibleModifier(M)
           [structural]
      rule (.K => CV("TCANON1", "Alignas attribute specifying an alignment less strict than would otherwise be required."))
           ~> addMods(.List, T:Type)
           requires isCompleteType(T)
                andBool getAlignas(T) <Int byteAlignofType(T)
+          [structural]
+     rule (.K => DeclType(S, D))
+          ~> addMods(_ ListItem(TAtomic(S:KItem, D:KItem)), _)
+          [structural]
+     rule (T:Type => .K)
+          ~> addMods(_::List ListItem(TAtomic(_, _) => atomic(T)), _)
+          [structural]
+     rule (.K => DeclType(S, D))
+          ~> addMods(_ ListItem(AlignasType(S:KItem, D:KItem)), _)
+          [structural]
+     rule (T:Type => .K)
+          ~> addMods(_::List ListItem(AlignasType(_, _) => alignas(byteAlignofType(T))), _)
+          [structural]
+     context addMods(_ ListItem(AlignasExpression(HOLE:KItem)), _)
+     rule addMods(_::List ListItem(AlignasExpression(tv(A:Int, _)) => alignas(A)), _)
+          [structural]
+     rule addMods(Mods::List (ListItem(S:KItem) => .List), _:KResult)
+          requires notBool isModifier(S)
+               andBool notBool isQualifier(S)
+               andBool notBool isReducibleModifier(S)
+          [structural]
+     rule addMods(.List, T:Type) => T
+          requires notBool isCompleteType(T)
+               orBool getAlignas(T) >=Int byteAlignofType(T)
           [structural]
 
      rule <k> canonicalizeSpecifier(ListItem(Named(X:CId)))
@@ -118,16 +135,6 @@ module C-TYPING-CANONICALIZATION
           ...</k>
           <types>... typedef(X) |-> T:Type ...</types>
           requires X =/=K #NoName
-          [structural]
-
-     rule canonicalizeSpecifier(Specs::List ListItem(EnumRef(X::CId, list(Attrs::List))))
-          => canonicalizeSpecifier(Attrs Specs ListItem(EnumRef(X, .K)))
-          [structural]
-     rule canonicalizeSpecifier(Specs::List ListItem(StructRef(X::CId, list(Attrs::List))))
-          => canonicalizeSpecifier(Attrs Specs ListItem(StructRef(X, .K)))
-          [structural]
-     rule canonicalizeSpecifier(Specs::List ListItem(UnionRef(X::CId, list(Attrs::List))))
-          => canonicalizeSpecifier(Attrs Specs ListItem(UnionRef(X, .K)))
           [structural]
 
      rule <k> canonicalizeSpecifier(ListItem(EnumRef(X:CId, .K)))
@@ -263,24 +270,6 @@ module C-TYPING-CANONICALIZATION
           <curr-program-loc> L::CabsLoc </curr-program-loc>
           <unnamed-locs>... .Map => unnamed(N,TU) |-> L ...</unnamed-locs>
           <next-unnamed> N:Int => N +Int 1 </next-unnamed>
-          [structural]
-
-     rule canonicalizeSpecifier((ListItem(S:KItem) => .List) _)
-          requires notBool isTypeSpecifier(S)
-               andBool notBool isReducibleSpecifier(S)
-          [structural]
-
-     rule canonicalizeSpecifier(Specs::List ListItem(EnumDef(X::CId, Fs:K, list(Attrs::List))))
-          => canonicalizeSpecifier(Attrs Specs ListItem(EnumDef(X, Fs, list(.List))))
-          requires Attrs =/=K .List
-          [structural]
-     rule canonicalizeSpecifier(Specs::List ListItem(StructDef(X::CId, Fs:K, list(Attrs::List))))
-          => canonicalizeSpecifier(Attrs Specs ListItem(StructDef(X, Fs, list(.List))))
-          requires Attrs =/=K .List
-          [structural]
-     rule canonicalizeSpecifier(Specs::List ListItem(UnionDef(X::CId, Fs:K, list(Attrs::List))))
-          => canonicalizeSpecifier(Attrs Specs ListItem(UnionDef(X, Fs, list(.List))))
-          requires Attrs =/=K .List
           [structural]
 
      rule (.K => EnumDef(X, L, list(.List)))

--- a/semantics/c/language/translation/typing/interpretation.k
+++ b/semantics/c/language/translation/typing/interpretation.k
@@ -1,10 +1,12 @@
 module C-TYPING-INTERPRETATION-SYNTAX
      imports BASIC-K
+     imports SET
      imports COMMON-SORTS
      imports C-DYNAMIC-SORTS
+     imports C-TYPING-SORTS
 
-     syntax Type ::= pushTypeDown(Type, K) [function]
-     syntax KItem ::= makeArrayType(RValue, K)
+     syntax KItem ::= pushTypeDown(Type, KItem)
+     syntax KItem ::= makeArrayType(Set, Set, RValue)
 
      syntax List ::= numberUnnamed(List) [function]
 endmodule
@@ -47,26 +49,26 @@ module C-TYPING-INTERPRETATION
                andBool notBool isBitfieldFieldType(T')
                andBool notBool isSimpleTypedefType(T')
 
-     syntax KItem ::= makeFunctionType(List)
-     syntax KItem ::= makeOldStyleFunctionType(List)
+     syntax KItem ::= makeFunctionType(Set, List)
+     syntax KItem ::= makeOldStyleFunctionType(Set, List)
      syntax KItem ::= makePointerType(Set)
-     syntax KItem ::= "makeIncompleteArrayType"
+     syntax KItem ::= makeIncompleteArrayType(Set, Set)
 
      context ArrayType(_, (HOLE:KItem => reval(HOLE)), _) [ndheat, result(RValue)]
-     rule ArrayType(T:Type, tv(N:Int, T'::UType), Spec:KItem)
-          => pushTypeDown(T, makeArrayType(tv(N, T'), Spec))
+     rule ArrayType(T:Type, tv(N:Int, T'::UType), Specifier(list(Specs::List)))
+          => pushTypeDown(T, makeArrayType(.Set, staticToArrayStatic(N, listToSet(Specs)), tv(N, T')))
           requires N >Int 0 andBool notBool isFlexibleType(T)
           [structural]
-     rule ArrayType(T:Type, UnspecifiedSizeExpression(), Spec:KItem)
-          => pushTypeDown(T, makeArrayType(UnspecifiedSizeExpression(), Spec))
+     rule ArrayType(T:Type, UnspecifiedSizeExpression(), Specifier(list(Specs::List)))
+          => pushTypeDown(T, makeArrayType(.Set, listToSet(Specs), UnspecifiedSizeExpression()))
           requires notBool isFlexibleType(T)
           [structural]
-     rule ArrayType(T:Type, N:RValue, Spec:KItem)
-          => pushTypeDown(T, makeArrayType(N, Spec))
+     rule ArrayType(T:Type, N:RValue, Specifier(list(Specs::List)))
+          => pushTypeDown(T, makeArrayType(.Set, listToSet(Specs), N))
           requires isHold(N) andBool notBool isFlexibleType(T) // VLAs
           [structural]
-     rule ArrayType(T:Type, emptyValue, _)
-          => pushTypeDown(T, makeIncompleteArrayType)
+     rule ArrayType(T:Type, emptyValue, Specifier(list(Specs::List)))
+          => pushTypeDown(T, makeIncompleteArrayType(.Set, listToSet(Specs)))
           requires notBool isFlexibleType(T)
           [structural]
      rule (.K => UNDEF("CTI1", "Arrays must have integer length."))
@@ -80,6 +82,11 @@ module C-TYPING-INTERPRETATION
           ~> ArrayType(T:Type, _, _)
           requires isFlexibleType(T)
           [structural]
+
+     syntax Set ::= staticToArrayStatic(Int, Set) [function]
+     rule staticToArrayStatic(N::Int, S::Set) => SetItem(arrayStatic(N)) (S -Set SetItem(Static()))
+          requires Static() in S
+     rule staticToArrayStatic(_, S::Set) => S [owise]
 
      rule PointerType(Specifier(list(Mods:List)), T:Type)
           => pushTypeDown(T, makePointerType(listToSet(Mods)))
@@ -105,78 +112,78 @@ module C-TYPING-INTERPRETATION
           ~> Prototype'(T:Type, L1:List, L2:List, Var:Bool)
           => declare(typedDeclaration(adjustParam(DT), X), NoInit())
           ~> Prototype'(T, L1, L2 ListItem(typedDeclaration(adjustParam(DT), X)), Var)
-     rule <k> Prototype'(T:Type, .List, L:List, false) => .K ...</k>
-          <elab> _ => pushTypeDown(T, makeFunctionType(L)) </elab>
-     rule <k> Prototype'(T:Type, .List, L:List, true) => .K ...</k>
-          <elab> _ => pushTypeDown(T, makeFunctionType(L ListItem(variadic))) </elab>
+     rule Prototype'(T:Type, .List, L:List, false)
+          => setElab(pushTypeDown(T, makeFunctionType(.Set, L)))
+     rule Prototype'(T:Type, .List, L:List, true)
+          => setElab(pushTypeDown(T, makeFunctionType(.Set, L ListItem(variadic))))
+
+     syntax KItem ::= setElab(KItem) [strict]
+     rule <k> setElab(V:KResult) => .K ...</k>
+          <elab> _ => V </elab>
 
      rule NoPrototype(T:Type, krlist(L:List), false)
-          => pushTypeDown(T, makeOldStyleFunctionType(adjustParams'(L)))
+          => pushTypeDown(T, makeOldStyleFunctionType(.Set, adjustParams'(L)))
 
-     rule pushTypeDown(t(... st: _:SimpleBasicType) #as T::Type, Lbl:K) => applyTypeFunction(Lbl, T)
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, arrayType(T::Type, N::Int)), Lbl:K)
-          => t(Qs, Mods, arrayType(pushTypeDown(T, Lbl), N))
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, unspecifiedArrayType(T::Type)), Lbl:K)
-          => t(Qs, Mods, unspecifiedArrayType(pushTypeDown(T, Lbl)))
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, variableLengthArrayType(T::Type, N:K)), Lbl:K)
-          => t(Qs, Mods, variableLengthArrayType(pushTypeDown(T, Lbl), N))
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, incompleteArrayType(T::Type)), Lbl:K)
-          => t(Qs, Mods, incompleteArrayType(pushTypeDown(T, Lbl)))
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, pointerType(T::Type)), Lbl:K)
-          => t(Qs, Mods, pointerType(pushTypeDown(T, Lbl)))
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, functionType(T::UType, L:List)), Lbl:K)
-          => t(Qs, Mods, functionType'(pushTypeDown(type(T), Lbl), L))
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, functionType'(T::Type, L:List)), Lbl:K)
-          => t(Qs, Mods, functionType'(pushTypeDown(T, Lbl), L))
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, structType(X::TagId)), Lbl:K)
+     rule pushTypeDown(t(... st: _:SimpleBasicType) #as T::Type, Lbl::KItem) => applyTypeFunction(Lbl, T)
+
+     rule pushTypeDown(t(quals(Qs::Set), Mods::Set, arrayType(T::Type, N::Int)), Lbl::KItem)
+          => applyTypeFunction(makeArrayType(Qs Mods, .Set, tv(N, utype(int))), pushTypeDown(T, Lbl))
+     rule pushTypeDown(t(quals(Qs::Set), Mods::Set, unspecifiedArrayType(T::Type)), Lbl::KItem)
+          => applyTypeFunction(makeArrayType(Qs Mods, .Set, UnspecifiedSizeExpression()), pushTypeDown(T, Lbl))
+     rule pushTypeDown(t(quals(Qs::Set), Mods::Set, variableLengthArrayType(T::Type, N::RValue)), Lbl::KItem)
+          => applyTypeFunction(makeArrayType(Qs Mods, .Set, N), pushTypeDown(T, Lbl))
+
+     rule pushTypeDown(t(quals(Qs::Set), Mods::Set, incompleteArrayType(T::Type)), Lbl::KItem)
+          => applyTypeFunction(makeIncompleteArrayType(Qs Mods, .Set), pushTypeDown(T, Lbl))
+     rule pushTypeDown(t(quals(Qs::Set), Mods::Set, pointerType(T::Type)), Lbl::KItem)
+          => applyTypeFunction(makePointerType(Qs Mods), pushTypeDown(T, Lbl))
+
+     rule pushTypeDown(t(quals(Qs::Set), Mods::Set, functionType(T::UType, L:List)), Lbl::KItem)
+          => applyTypeFunction(makeFunctionType(Qs Mods, L), pushTypeDown(type(T), Lbl))
+     rule pushTypeDown(t(quals(Qs::Set), Mods::Set, functionType'(T::Type, L:List)), Lbl::KItem)
+          => applyTypeFunction(makeFunctionType(Qs Mods, L), pushTypeDown(T, Lbl))
+
+     rule pushTypeDown(t(Qs::Quals, Mods::Set, structType(X::TagId)), Lbl::KItem)
           => applyTypeFunction(Lbl, t(Qs, Mods, structType(X)))
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, unionType(X::TagId)), Lbl:K)
+     rule pushTypeDown(t(Qs::Quals, Mods::Set, unionType(X::TagId)), Lbl::KItem)
           => applyTypeFunction(Lbl, t(Qs, Mods, unionType(X)))
-     rule pushTypeDown(t(Qs::Quals, Mods::Set, typedefType(X:CId, T::Type)), Lbl:K)
+     rule pushTypeDown(t(Qs::Quals, Mods::Set, typedefType(X:CId, T::Type)), Lbl::KItem)
           => applyTypeFunction(Lbl, t(Qs, Mods, typedefType(X, T)))
 
-     syntax Type ::= applyTypeFunction(K, Type) [function]
+     syntax KItem ::= applyTypeFunction(K, KItem) [strict(2)]
      syntax SimpleType ::= "functionType'" "(" Type "," List ")"
-     rule applyTypeFunction(makeFunctionType(L:List), T::Type)
-          => t(noQuals, getSpecifiers(T),
-               functionType'(stripSpecifiers(T), numberUnnamed(L)))
+     rule applyTypeFunction(makeFunctionType(Mods::Set, L:List), t(...) #as T::Type)
+          => addMods(Set2List(Mods getSpecifiers(T)), type(functionType'(stripSpecifiers(T), numberUnnamed(L))))
+     rule applyTypeFunction(makeOldStyleFunctionType(Mods::Set, L:List), t(...) #as T::Type)
+          => addMods(Set2List(Mods getSpecifiers(T) SetItem(oldStyle)), type(functionType'(stripSpecifiers(T), numberUnnamed(L))))
+     rule applyTypeFunction(makePointerType(Mods::Set), t(...) #as T::Type)
+          => addMods(Set2List(Mods getSpecifiers(T)), type(pointerType(stripSpecifiers(T))))
 
-     rule applyTypeFunction(makeOldStyleFunctionType(L:List), T::Type)
-          => t(noQuals, getSpecifiers(T) SetItem(oldStyle),
-               functionType'(stripSpecifiers(T), numberUnnamed(L)))
-
-     rule applyTypeFunction(makePointerType(Mods::Set), T::Type)
-          => t(toQuals(Mods), (Mods -Set typeQualifiers) getSpecifiers(T), pointerType(stripSpecifiers(T)))
-
-     rule applyTypeFunction(makeIncompleteArrayType, T::Type)
-          => t(noQuals, getSpecifiers(T), incompleteArrayType(stripSpecifiers(T)))
-
-     rule applyTypeFunction(makeArrayType(tv(N:Int, _), Specifier(list(Specs::List))), T::Type)
-          => t(toQuals(List2Set(Specs)), getSpecifiers(T) SetItem(arrayStatic(N)), arrayType(stripSpecifiers(T), N))
-          requires Static() in Specs
-     rule applyTypeFunction(makeArrayType(tv(N:Int, _), Specifier(list(Specs::List))), T::Type)
-          => t(toQuals(List2Set(Specs)), getSpecifiers(T), arrayType(stripSpecifiers(T), N))
-          requires notBool (Static() in Specs)
-     // TODO(chathhorn): Other qualifiers?
-     rule applyTypeFunction(makeArrayType(tv(N:Int, _), Specifier(list(.List))), T::Type)
-          => t(noQuals, getSpecifiers(T), arrayType(stripSpecifiers(T), N))
-     rule applyTypeFunction(makeArrayType(UnspecifiedSizeExpression(), Specifier(list(.List))), T::Type)
-          => t(noQuals, getSpecifiers(T), unspecifiedArrayType(stripSpecifiers(T)))
-     rule applyTypeFunction(makeArrayType(N:RValue, Specifier(list(.List))), T::Type)
-          => t(noQuals, getSpecifiers(T), variableLengthArrayType(stripSpecifiers(T), N))
+     rule applyTypeFunction(makeIncompleteArrayType(Mods::Set, ParamMods::Set), t(...) #as T::Type)
+          => setQuals(ParamMods, addMods(Set2List(Mods getSpecifiers(T) (ParamMods -Set typeQualifiers)), type(incompleteArrayType(stripSpecifiers(T)))))
+     rule applyTypeFunction(makeArrayType(Mods::Set, ParamMods::Set, tv(N:Int, _)), t(...) #as T::Type)
+          => setQuals(ParamMods, addMods(Set2List(Mods getSpecifiers(T) (ParamMods -Set typeQualifiers)), type(arrayType(stripSpecifiers(T), N))))
+     rule applyTypeFunction(makeArrayType(Mods::Set, ParamMods::Set, UnspecifiedSizeExpression()), t(...) #as T::Type)
+          => setQuals(ParamMods, addMods(Set2List(Mods getSpecifiers(T) (ParamMods -Set typeQualifiers)), type(unspecifiedArrayType(stripSpecifiers(T)))))
+     rule applyTypeFunction(makeArrayType(Mods::Set, ParamMods::Set, N:RValue), t(...) #as T::Type)
+          => setQuals(ParamMods, addMods(Set2List(Mods getSpecifiers(T) (ParamMods -Set typeQualifiers)), type(variableLengthArrayType(stripSpecifiers(T), N))))
           requires isHold(N)
+
+     syntax KItem ::= setQuals(Set, KItem) [strict(2)]
+
+     rule setQuals(M::Set, t(Qs::Quals, Mods::Set, T::SimpleType))
+          => t(Qs +Quals toQuals(M), Mods, T)
 
      rule <k> JustBase() => T ...</k>
           <decl-type-holder> T:Type => .K ...</decl-type-holder>
           [structural]
 
-     syntax KItem ::= "extractActualTypeFreezer"
-     rule <k> DeclType(T:Type, K:KItem) => K ~> extractActualTypeFreezer ...</k>
+     rule <k> DeclType(T:Type, K:KItem) => extractActualTypeFreezer(K) ...</k>
           <decl-type-holder> (.K => T) ...</decl-type-holder>
           [structural]
 
-     rule T:Type ~> extractActualTypeFreezer
-          => extractActualType(T)
+     syntax KItem ::= extractActualTypeFreezer(KItem) [strict]
+     rule extractActualTypeFreezer(t(...) #as T::Type) => extractActualType(T)
           [structural]
 
      // The K will resolve to a type, so throw it away.

--- a/semantics/common/compat.k
+++ b/semantics/common/compat.k
@@ -70,13 +70,6 @@ module COMPAT-SYNTAX
      // Turns a (hopefully injective!) map with {k_1 |-> v_1, ..., k_n |-> v_n} into {v_1 |-> k_1, ..., v_n |-> k_n}.
      syntax Map ::= invertMap(Map) [function]
 
-     syntax SSList ::= toSSList(List) [function]
-     syntax List ::= ofSSList(SSList) [function]
-     syntax SList ::= toSList(List) [function]
-     syntax List ::= ofSList(SList) [function]
-
-     syntax KItem ::= seqstrict(StrictList)
-
      syntax Map ::= Map "[" K "," K "<-" K "]" [function]
      syntax Map ::= Map "[" K "+=" K "]" [function]
      syntax Map ::= Map "[" K "<+" Map "]" [function]

--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -563,6 +563,14 @@ module CPP-DYNAMIC-OTHER-SYNTAX
      syntax Stmt ::= compoundStmt(Stmt, Stmt)
      syntax Stmt ::= nullStmt()
 
+     syntax SSList ::= toSSList(List) [klabel(toSSListcpp), function]
+     syntax List ::= ofSSList(SSList) [klabel(ofSSListcpp), function]
+     syntax SList ::= toSList(List) [klabel(toSListcpp), function]
+     syntax List ::= ofSList(SList) [klabel(ofSListcpp), function]
+
+     syntax KItem ::= seqstrict(StrictList) [klabel(seqstrictcpp)]
+
+
 endmodule // CPP-DYNAMIC-OTHER-SYNTAX
 
 module CPP-DYNAMIC-OTHER
@@ -706,17 +714,17 @@ module CPP-DYNAMIC-OTHER
 
      context K:KResult typeStrict:: HOLE:STypeStrictList
 
-     syntax ExecResult ::= V
+     syntax ExecResult ::= V | ValResult
 
-     syntax KItem ::= "seqstrict()"
+     syntax KItem ::= "seqstrict()" [klabel(seqstrictlist-cpp)]
      rule seqstrict(list(HOLE:List)) => toSSList(HOLE) ~> seqstrict() [heat]
      rule <k> HOLE:SSList ~> seqstrict() => seqstrict(krlist(ofSSList(HOLE))) ...</k>
           <compile-time-evaluation> false </compile-time-evaluation> [cool]
      rule <k> HOLE:SSList ~> seqstrict() => seqstrict(krlist(ofSSList(HOLE))) ...</k>
           <compile-time-evaluation> true </compile-time-evaluation> [cool, result(ExecResult)]
 
-     syntax SSList ::= KItem "seqstrict::" SSList [seqstrict(c)]
-                     | ".SSList"
+     syntax SSList ::= KItem "seqstrict::" SSList [klabel(seqstrictlist-sep-cpp), seqstrict(c)]
+                     | ".SSList" [klabel(seqstrictlist-unit-cpp)]
      rule isKResult(.SSList) => true
      rule isKResult(S1::SSList seqstrict:: S2::SSList) => isKResult(S1) andBool isKResult(S2)
      rule isExecResult(.SSList) => true
@@ -727,15 +735,15 @@ module CPP-DYNAMIC-OTHER
      rule ofSSList(.SSList) => .List
      rule ofSSList(K:KItem seqstrict:: L::SSList) => ListItem(K) ofSSList(L) [owise]
 
-     syntax KItem ::= "strict()"
+     syntax KItem ::= "strict()" [klabel(strictlist-cpp)]
      rule list(HOLE:List) => toSList(HOLE) ~> strict() [heat]
      rule <k> HOLE:SList ~> strict() => krlist(ofSList(HOLE)) ...</k>
           <compile-time-evaluation> false </compile-time-evaluation> [cool]
      rule <k> HOLE:SList ~> strict() => krlist(ofSList(HOLE)) ...</k>
           <compile-time-evaluation> true </compile-time-evaluation> [cool, result(ExecResult)]
 
-     syntax SList ::= KItem "strict::" SList [strict(c)]
-                    | ".SList"
+     syntax SList ::= KItem "strict::" SList [klabel(strictlist-sep-cpp), strict(c)]
+                    | ".SList" [klabel(strictlist-unit-cpp)]
      rule isKResult(.SList) => true
      rule isKResult(S1::SList strict:: S2::SList) => isKResult(S1) andBool isKResult(S2)
      rule isExecResult(.SList) => true
@@ -745,8 +753,6 @@ module CPP-DYNAMIC-OTHER
      rule ofSList(krlist(L1::List) strict:: L2::SList) => L1 ofSList(L2)
      rule ofSList(.SList) => .List
      rule ofSList(K:KItem strict:: L::SList) => ListItem(K) ofSList(L) [owise]
-
-
 
      rule locOf(lv(L::SymLoc, _, _)) => L
 

--- a/tests/check-results.mk
+++ b/tests/check-results.mk
@@ -2,4 +2,4 @@
 
 CHECK_RESULT_COMPILE = if [ $$? -eq 0 ] ; then echo "passed $<"; mv $@.tmp.out $@.out; else echo "failed $<"; cat $@.tmp.out; exit 1; fi
 CHECK_RESULT_RUN = if [ $$? -eq 0 ] ; then echo "passed $<"; mv $@.tmp $@; else echo "failed $<"; cat $@.tmp; exit 1; fi
-CHECK_RESULT_RUN_VERBOSE = if [ $$? -eq 0 ] ; then echo "passed $<"; mv $@.tmp $@; else echo "failed $<"; cat $@.tmp; env VERBOSE=1 ./$<; exit 1; fi
+CHECK_RESULT_RUN_VERBOSE = if [ $$? -eq 0 ] ; then echo "passed $<"; mv $@.tmp $@; else echo "failed $<"; cat $@.tmp; env VERBOSE=1 ./$< > $@.log 2>&1; exit 1; fi

--- a/tests/unit-pass/20001024-1.c
+++ b/tests/unit-pass/20001024-1.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 struct a;
 
-extern int baz (struct a *__restrict x);
+extern int baz (struct a *restrict x);
 
 struct a {
   long v;
@@ -13,7 +13,7 @@ struct b {
   struct a d;
 };
 
-int bar (int x, const struct b *__restrict y, struct b *__restrict z)
+int bar (int x, const struct b *restrict y, struct b *restrict z)
 {
   if (y->c.v || y->c.w != 250000 || y->d.v || y->d.w != 250000)
     abort();

--- a/tests/unit-pass/20080506-2.c
+++ b/tests/unit-pass/20080506-2.c
@@ -4,7 +4,7 @@
 extern void abort (void);
 
 void __attribute__((noinline))
-foo (int **__restrict p, int **__restrict q)
+foo (int **restrict p, int **restrict q)
 {
   *p[0] = 1;
   *q[0] = 2;

--- a/tests/unit-pass/20090623-1.c
+++ b/tests/unit-pass/20090623-1.c
@@ -1,5 +1,5 @@
 #include "fsl-header.h"
-int * __restrict__ x;
+int * restrict x;
 
 int foo (int y)
 {

--- a/tests/unit-pass/Makefile
+++ b/tests/unit-pass/Makefile
@@ -116,7 +116,7 @@ zeroinit-class-padding.C.cmp:
 
 .PHONY: clean
 clean:
-	rm -rf *.out *.kcc *.tmp *.gcc *.ref *.cmp
+	rm -rf *.out *.kcc *.tmp *.gcc *.ref *.cmp *.log
 
 .PHONY: clean-c
 clean-c:

--- a/tests/unit-pass/restrict-1.c
+++ b/tests/unit-pass/restrict-1.c
@@ -16,7 +16,7 @@ static inline A foo (const A* p, const A* q)
   return (A){p->i+q->i};
 }
 
-void bar (A* __restrict__ p)
+void bar (A* restrict p)
 {
   *p=foo(p,p);
   if (p->i!=2)


### PR DESCRIPTION
* Disambiguates some cpp klabels to fix an issue with `strict::` lists causing the Match release build to sometimes fail.
* Refactors semantics of specifier/qualifier canonicalization to fix some issues with adding new attributes.
* Change to send verbose output of the unit-pass tests to a file instead of to stdout.