### PR TITLE
Fix functional cast

### DIFF
--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -507,6 +507,8 @@ module CPP-DYNAMIC-OTHER-SYNTAX
      syntax TemplateArgs ::= toTemplateArgs(List) [function]
                            | toTemplateArgs(CPPTypes) [function, klabel(CPPTypesToTemplateArgs)]
 
+     syntax Int ::= CPPTypesSize(CPPTypes) [function]
+
      syntax List ::= toList(CPPTypes) [function]
                    | toList(TemplateArgs) [function]
 
@@ -778,6 +780,8 @@ module CPP-DYNAMIC-OTHER
      rule toCPPTypes(.List) => .CPPTypes
 
      rule toCPPTypes(T::TemplateArgs) => toCPPTypes(toList(T))
+
+     rule CPPTypesSize(Ts::CPPTypes) => size(toList(Ts))
 
      rule toList(T::CPPType, Ts::CPPTypes) => ListItem(T) toList(Ts)
 

--- a/semantics/cpp/language/common/typing.k
+++ b/semantics/cpp/language/common/typing.k
@@ -162,6 +162,8 @@ module CPP-TYPING-SYNTAX
 
      syntax CPPSimpleFunctionType ::= functionType(returnType: CPPType, paramTypes: CPPTypes, methodInfo: MethodInfo, linkage: LanguageLinkage, exceptions: ExceptionSet) [klabel(cppFunctionType)]
 
+     syntax Int ::= paramCount(CPPSimpleFunctionType) [function]
+
      syntax CPPSimpleClassType ::= classType(Class)
 
      syntax CPPSimpleDependentType ::= dependentType(String, Int)
@@ -399,6 +401,8 @@ module CPP-TYPING
      imports CPP-SYNTAX
      imports CPP-SYMLOC-SYNTAX
      imports CPP-TYPE-MAP-SYNTAX
+
+     rule paramCount(functionType(... paramTypes: Ts::CPPTypes)) => CPPTypesSize(Ts)
 
      rule getParams(t(_, _, functionType(... paramTypes: L::CPPTypes, methodInfo: noMethod))) => toList(L)
 

--- a/semantics/cpp/language/translation/overloading.k
+++ b/semantics/cpp/language/translation/overloading.k
@@ -379,7 +379,15 @@ module CPP-TRANSLATION-OVERLOADING
                     | #computeUDCTo(Class, List, CPPType, ValueCategory, List)
 
      rule computeUDCTo(_ :: Class(_, X::CId, _) #as P::Class, <class>... <cenv>... ConstructorId(X) |-> M::Map ...</cenv> ...</class>, A::CPPType, C::ValueCategory)
-          => #computeUDCTo(P, keys_list(stripExplicit(M)), A, C, .List)
+          => #computeUDCTo(P, singleParamFunctions(keys_list(stripExplicit(M))), A, C, .List)
+
+     syntax List ::= singleParamFunctions(List) [function]
+
+     rule singleParamFunctions(ListItem(t(... st: ST::CPPSimpleFunctionType) #as FuncT::CPPType) L::List)
+          => #if paramCount(ST) ==Int 1 #then ListItem(FuncT) #else .List #fi
+             singleParamFunctions(L)
+
+     rule singleParamFunctions(.List) => .List
 
      rule (.K => computeUserDefinedConversionSequence(
                computeConversionSequence(Param, A, C, false, false, false),

--- a/tests/unit-pass/functional-cast-4.C
+++ b/tests/unit-pass/functional-cast-4.C
@@ -1,0 +1,12 @@
+struct S{
+	S(){}
+	S(int, float){}
+	S(int) {}
+};
+
+int main() {
+	S s1 = S(1);
+	S s2 = S{2};
+	S s3 = S(3,4);
+	S s4 = S();	
+}


### PR DESCRIPTION
`#computeUDCTo` does not play well with constructors that do not have exactly one parameter -> filter them out.
RV-Match test: https://github.com/runtimeverification/rv-match/pull/1087