### PR TITLE
Delete local object just after its destruction.

### DIFF
--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -574,8 +574,6 @@ module CPP-DYNAMIC-OTHER-SYNTAX
 
      syntax KItem ::= seqstrict(StrictList) [klabel(seqstrictcpp)]
 
-     syntax SymBase ::= baseOfLoc(SymLoc) [function]
-
 endmodule // CPP-DYNAMIC-OTHER-SYNTAX
 
 module CPP-DYNAMIC-OTHER
@@ -1076,8 +1074,6 @@ module CPP-DYNAMIC-OTHER
      rule idOf(Class(_, X::CId, _)) => X
 
      rule idOf(_ :: S::ClassSpecifier) => idOf(S)
-
-     rule baseOfLoc(loc(Base::SymBase, _) #Or loc(Base::SymBase, _, _)) => Base
 
 endmodule // CPP-DYNAMIC-OTHER
 

--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -574,6 +574,7 @@ module CPP-DYNAMIC-OTHER-SYNTAX
 
      syntax KItem ::= seqstrict(StrictList) [klabel(seqstrictcpp)]
 
+     syntax SymBase ::= baseOfLoc(SymLoc) [function]
 
 endmodule // CPP-DYNAMIC-OTHER-SYNTAX
 
@@ -1075,6 +1076,8 @@ module CPP-DYNAMIC-OTHER
      rule idOf(Class(_, X::CId, _)) => X
 
      rule idOf(_ :: S::ClassSpecifier) => idOf(S)
+
+     rule baseOfLoc(loc(Base::SymBase, _) #Or loc(Base::SymBase, _, _)) => Base
 
 endmodule // CPP-DYNAMIC-OTHER
 

--- a/semantics/cpp/language/execution/binding.k
+++ b/semantics/cpp/language/execution/binding.k
@@ -17,6 +17,7 @@ module CPP-EXECUTION-BINDING
      imports INT
      imports CPP-CLASS-SYNTAX
      imports CPP-DYNAMIC-SYNTAX
+     imports CPP-EXECUTION-STMT-BLOCK-SYNTAX
      imports CPP-EXPR-MEMBERS-SYNTAX
      imports CPP-MEMORY-WRITING-SYNTAX
      imports CPP-SYNTAX
@@ -64,7 +65,7 @@ module CPP-EXECUTION-BINDING
      rule <k> finishConstruction(Obj:LVal, IsConstructor:Bool) => Obj ...</k>
           <locally-constructed> .List =>
           #if IsConstructor #then
-               ListItem(ktriple(Obj, true, true))
+               ListItem(lcentry(Obj, true, true, true))
           #else .List #fi
           ...</locally-constructed>
 

--- a/semantics/cpp/language/execution/binding.k
+++ b/semantics/cpp/language/execution/binding.k
@@ -61,8 +61,12 @@ module CPP-EXECUTION-BINDING
      rule <k> endConstruction(Obj:LVal, IsConstructor::Bool) => finishConstruction(Obj, IsConstructor) ...</k>
           <constructing> _ => .K </constructing>
 
-     rule <k> finishConstruction(Obj:LVal, IsConstructor::Bool) => Obj ...</k>
-          <locally-constructed> .List => ListItem(ktriple(Obj, true, IsConstructor)) ...</locally-constructed>
+     rule <k> finishConstruction(Obj:LVal, IsConstructor:Bool) => Obj ...</k>
+          <locally-constructed> .List =>
+          #if IsConstructor #then
+               ListItem(ktriple(Obj, true, true))
+          #else .List #fi
+          ...</locally-constructed>
 
      rule <k> writeVTables => write(Loc, prv(vtable(MDC), noTrace, type(pointerType(type(void)))), type(pointerType(type(void)))) ...</k>
           <curr-scope> blockScope(C::Class :: _, _, _) </curr-scope>

--- a/semantics/cpp/language/execution/decl/declarator.k
+++ b/semantics/cpp/language/execution/decl/declarator.k
@@ -5,6 +5,7 @@ module CPP-EXECUTION-DECL-DECLARATOR
      imports CPP-BITSIZE-SYNTAX
      imports CPP-DYNAMIC-SYNTAX
      imports CPP-EXECUTION-ENV-SYNTAX
+     imports CPP-EXECUTION-STMT-BLOCK-SYNTAX
      imports CPP-MEMORY-ALLOC-SYNTAX
      imports CPP-SYMLOC-SYNTAX
      imports CPP-SYNTAX
@@ -22,11 +23,12 @@ module CPP-EXECUTION-DECL-DECLARATOR
                  #else .K #fi
               ~> initializeObjectExec(Init)
               ~> #if notBool isCPPRefType(T) #then
-                    updateRegisteredForDestruction()
+                    updateRegisteredForDestruction(size(LC))
                  #else .K #fi
           ...</k>
           <duration> D::Duration </duration>
           <local-vars> Vars:Set (.Set => SetItem(X)) </local-vars>
+          <locally-constructed> LC::List </locally-constructed>
           requires notBool X in Vars andBool X =/=K #NoName
 
      syntax KItem ::= registerForDestruction(Expr) [strict(1)]
@@ -37,18 +39,44 @@ module CPP-EXECUTION-DECL-DECLARATOR
      // the allocated object gets deleted.
      // The `IsConstructor` flag is cleared later
      // in `updateRegisteredForDestruction()`.
-     // TODO what happens with references?
      rule <k> registerForDestruction(Obj:LVal) => .K ...</k>
           <locally-constructed> .List =>
-               ListItem(ktriple(Obj, true, true))
+               ListItem(lcentry(Obj, false, true, false))
           ...</locally-constructed>
 
-     syntax KItem ::= updateRegisteredForDestruction()
+     syntax KItem ::= updateRegisteredForDestruction(Int)
+                    | updateRegisteredForDestruction2(idx: Int, entry: KItem)
 
-     rule <k> updateRegisteredForDestruction() => .K ...</k>
+     // `-1 -Int Size` from the end is the index of the newly-added entry
+     rule <k> updateRegisteredForDestruction(Size::Int)
+          => updateRegisteredForDestruction2(-1 -Int Size, LC[-1 -Int Size])
+          ...</k>
+          <locally-constructed> LC::List </locally-constructed>
+
+     rule <k> updateRegisteredForDestruction2(Idx::Int,
+               lcentry(Obj::LVal, false, CanBeVirtual::Bool, IsConstructor::Bool)) => .K
+          ...</k>
           <locally-constructed>
-               ListItem(ktriple(_, _, true => false))
-          ...</locally-constructed>
+               LC::List => myListUpdate(LC, (size(LC) +Int Idx), lcentry(Obj, true, CanBeVirtual, IsConstructor))
+          </locally-constructed>
+
+     // implements List[Idx <- Val]
+     syntax List ::= myListUpdate(List, Int, KItem) [function]
+                   | #myListUpdate(List, List, Int, KItem) [function]
+
+     rule myListUpdate(L::List, Idx::Int, V::KItem)
+          => #myListUpdate(.List, L, Idx, V)
+
+     rule #myListUpdate(L1::List, ListItem(_) L2::List, 0, V::KItem)
+          => L1 ListItem(V) L2
+
+     rule #myListUpdate(
+               _::List (.List => ListItem(V)),
+               (ListItem(V::KItem) => .List) _,
+               N::Int => N -Int 1,
+               _
+          )
+          requires N >Int 0
 
      rule declareNonStaticObjectExec(#NoName, _, Init::Expr, _, _, _) => ExpressionStmt(Init)
 

--- a/semantics/cpp/language/execution/decl/declarator.k
+++ b/semantics/cpp/language/execution/decl/declarator.k
@@ -13,10 +13,17 @@ module CPP-EXECUTION-DECL-DECLARATOR
      syntax KItem ::= initializeObjectExec(K)
 
      rule <k> declareNonStaticObjectExec(X::CId, T::CPPType, Init::Expr, Var(_), AutoStorage, Mods::Set)
-              => #if notBool isCPPRefType(T) #then allocObject(bnew(!I:Int, T, Mods, D), T, byteSizeofType(T)) #else .K #fi
+              => #if notBool isCPPRefType(T) #then
+                    allocObject(bnew(!I:Int, T, Mods, D), T, byteSizeofType(T))
+                 #else .K #fi
               ~> addToExecEnv(X, T, bnew(!I:Int, T, Mods, D), false)
+              ~> #if notBool isCPPRefType(T) #then
+                    registerForDestruction(ExecName(NoNNS(), X))
+                 #else .K #fi
               ~> initializeObjectExec(Init)
-              ~> registerForDestruction(ExecName(NoNNS(), X))
+              ~> #if notBool isCPPRefType(T) #then
+                    updateRegisteredForDestruction()
+                 #else .K #fi
           ...</k>
           <duration> D::Duration </duration>
           <local-vars> Vars:Set (.Set => SetItem(X)) </local-vars>
@@ -24,9 +31,23 @@ module CPP-EXECUTION-DECL-DECLARATOR
 
      syntax KItem ::= registerForDestruction(Expr) [strict(1)]
 
+     // we register the object for destruction before
+     // its initializer runs (but with the `IsConstructor` flag set)
+     // so that if an exception is thrown in the initializer,
+     // the allocated object gets deleted.
+     // The `IsConstructor` flag is cleared later
+     // in `updateRegisteredForDestruction()`.
+     // TODO what happens with references?
      rule <k> registerForDestruction(Obj:LVal) => .K ...</k>
           <locally-constructed> .List =>
-               ListItem(ktriple(Obj, true, false))
+               ListItem(ktriple(Obj, true, true))
+          ...</locally-constructed>
+
+     syntax KItem ::= updateRegisteredForDestruction()
+
+     rule <k> updateRegisteredForDestruction() => .K ...</k>
+          <locally-constructed>
+               ListItem(ktriple(_, _, true => false))
           ...</locally-constructed>
 
      rule declareNonStaticObjectExec(#NoName, _, Init::Expr, _, _, _) => ExpressionStmt(Init)

--- a/semantics/cpp/language/execution/decl/declarator.k
+++ b/semantics/cpp/language/execution/decl/declarator.k
@@ -16,11 +16,18 @@ module CPP-EXECUTION-DECL-DECLARATOR
               => #if notBool isCPPRefType(T) #then allocObject(bnew(!I:Int, T, Mods, D), T, byteSizeofType(T)) #else .K #fi
               ~> addToExecEnv(X, T, bnew(!I:Int, T, Mods, D), false)
               ~> initializeObjectExec(Init)
+              ~> registerForDestruction(ExecName(NoNNS(), X))
           ...</k>
           <duration> D::Duration </duration>
           <local-vars> Vars:Set (.Set => SetItem(X)) </local-vars>
-          <local-addresses>... .Set => SetItem(bnew(!I:Int, T, Mods, D)) ...</local-addresses>
           requires notBool X in Vars andBool X =/=K #NoName
+
+     syntax KItem ::= registerForDestruction(Expr) [strict(1)]
+
+     rule <k> registerForDestruction(Obj:LVal) => .K ...</k>
+          <locally-constructed> .List =>
+               ListItem(ktriple(Obj, true, false))
+          ...</locally-constructed>
 
      rule declareNonStaticObjectExec(#NoName, _, Init::Expr, _, _, _) => ExpressionStmt(Init)
 

--- a/semantics/cpp/language/execution/decl/declarator.k
+++ b/semantics/cpp/language/execution/decl/declarator.k
@@ -34,10 +34,10 @@ module CPP-EXECUTION-DECL-DECLARATOR
      syntax KItem ::= registerForDestruction(Expr) [strict(1)]
 
      // we register the object for destruction before
-     // its initializer runs (but with the `IsConstructor` flag set)
+     // its initializer runs (but with the `initialized` flag cleared)
      // so that if an exception is thrown in the initializer,
      // the allocated object gets deleted.
-     // The `IsConstructor` flag is cleared later
+     // The `initialized` flag is set later
      // in `updateRegisteredForDestruction()`.
      rule <k> registerForDestruction(Obj:LVal) => .K ...</k>
           <locally-constructed> .List =>

--- a/semantics/cpp/language/execution/expr/function-call.k
+++ b/semantics/cpp/language/execution/expr/function-call.k
@@ -163,7 +163,7 @@ module CPP-EXECUTION-EXPR-FUNCTION-CALL
      syntax SymBase ::= getBaseOfVal(Val) [function]
 
      rule getBaseOfVal(lv(...v: L::SymLoc) #Or xv(...v: L::SymLoc) #Or prv(...v: L::SymLoc))
-          => baseOfLoc(L)
+          => base(L)
 
      rule getBaseOfVal(referenceBindingResult(V::Val))
           => getBaseOfVal(V)

--- a/semantics/cpp/language/execution/expr/function-call.k
+++ b/semantics/cpp/language/execution/expr/function-call.k
@@ -168,10 +168,6 @@ module CPP-EXECUTION-EXPR-FUNCTION-CALL
      rule getBaseOfVal(referenceBindingResult(V::Val))
           => getBaseOfVal(V)
 
-     syntax SymBase ::= baseOfLoc(SymLoc) [function]
-
-     rule baseOfLoc(loc(Base::SymBase, _)) => Base
-
      rule <k> bindParam(X::CId, T::CPPType, V:Val)
               => addToExecEnv(X, T, getBaseOfVal(V), false)
            ...</k>

--- a/semantics/cpp/language/execution/stmt/block.k
+++ b/semantics/cpp/language/execution/stmt/block.k
@@ -29,7 +29,6 @@ module CPP-EXECUTION-STMT-BLOCK
                C::Bag
                <catch-handlers> Catch::List => .List </catch-handlers>
                <local-vars> Vars::Set => .Set </local-vars>
-               <local-addresses> Addresses::Set => .Set </local-addresses>
                <locally-constructed> Constructed::List => .List </locally-constructed>
           </block-control>
           <block-stack> .List
@@ -37,7 +36,6 @@ module CPP-EXECUTION-STMT-BLOCK
                     C
                     <catch-handlers> Catch </catch-handlers>
                     <local-vars> Vars </local-vars>
-                    <local-addresses> Addresses </local-addresses>
                     <locally-constructed> Constructed </locally-constructed>
                </block-control>)
           ...</block-stack>
@@ -52,9 +50,20 @@ module CPP-EXECUTION-STMT-BLOCK
           <curr-scope> blockScope(_, _, (_ => 0)) </curr-scope>
           <block-history> .List </block-history>
 
-     rule <k> popBlock(IsException::Bool) => destructLocals(IsException) ~> unfoldBlockStack ~> deleteObjects(Locals) ~> exitRestrictBlock(Locals) ~> updateScope ...</k>
-          <local-addresses> Locals::Set </local-addresses>
+     rule popBlock(IsException::Bool) => destructLocals(IsException) ~> unfoldBlockStack ~> exitRestrictBlock(getLocalAddresses()) ~> updateScope
           [structural]
+
+     syntax Set ::= getLocalAddresses() [function]
+                  | #getLocalAddresses(List, Set)
+
+     rule [[ getLocalAddresses() => #getLocalAddresses(LC, .Set) ]]
+          <locally-constructed> LC::List </locally-constructed>
+
+     rule #getLocalAddresses(.List, S::Set) => S
+     rule #getLocalAddresses(
+               (ListItem(ktriple(lv(Loc::SymLoc, _, _), _, _)) => .List) _,
+               (.Set => SetItem(baseOfLoc(Loc))) _
+          )
 
      rule <k> addToConstructed(L:LVal, t(... st: classType(...)) #as T::CPPType) => .K ...</k>
           <locally-constructed> .List => ListItem(ktriple(L, false, false)) ...</locally-constructed>
@@ -68,13 +77,36 @@ module CPP-EXECUTION-STMT-BLOCK
      // we have to atomically remove the item from locally-constructed and call the destructor as a single operation
      // because the destructor could throw an exception that unwinds back through this block, in which case the
      // destructor should not be called again. See http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#2176
-     rule <k> (.K => #if IsConstructor andBool notBool IsException #then .K #else destruct(V, CanBeVirtual) ~> fullExpression #fi)
+
+     rule <k> (.K => destructLocal(IsException, Entry))
               ~> destructLocals(IsException:Bool)
           ...</k>
-          <locally-constructed> ListItem(ktriple(lv(Loc::SymLoc, _, _) #as V::LVal, CanBeVirtual::Bool, IsConstructor:Bool)) => .List ...</locally-constructed>
+          <locally-constructed> ListItem(Entry::KTuple) => .List ...</locally-constructed>
 
      rule <k> destructLocals(...) => .K ...</k>
           <locally-constructed> .List </locally-constructed>
+
+     syntax KItem ::= destructLocal(isException: Bool, entry: KTuple)
+
+     rule destructLocal(IsException:Bool,
+               ktriple(
+                    lv(Loc::SymLoc, _, _) #as V::LVal,
+                    CanBeVirtual::Bool,
+                    IsConstructor:Bool
+               )
+          )
+          =>
+          #if IsConstructor andBool notBool IsException #then
+               .K
+          #else
+               destruct(V, CanBeVirtual) ~> fullExpression
+          #fi
+          ~>
+          #if IsConstructor #then
+               .K
+          #else
+               deleteObject(baseOfLoc(Loc))
+          #fi
 
      syntax KItem ::= "unfoldBlockStack"
 
@@ -95,5 +127,8 @@ module CPP-EXECUTION-STMT-BLOCK
           <tu-id> Tu </tu-id>
           <class-id> C </class-id>
           <cenv>... DestructorId(X) |-> (_::CPPType |-> (FuncT::CPPType, envEntry(... base: Base::SymBase))) ...</cenv>
+
+     rule destruct(lv(_, _, T::CPPType), _) => .K
+          requires notBool isCPPClassType(T)
 
 endmodule

--- a/semantics/cpp/language/execution/stmt/block.k
+++ b/semantics/cpp/language/execution/stmt/block.k
@@ -1,3 +1,15 @@
+module CPP-EXECUTION-STMT-BLOCK-SYNTAX
+     imports BOOL
+
+     syntax LVal
+
+     syntax KItem ::= lcentry(
+                         val: LVal,
+                         initialized: Bool,
+                         canBeVirtual: Bool,
+                         isConstructor: Bool)
+endmodule
+
 module CPP-EXECUTION-STMT-BLOCK
      imports C-CONFIGURATION
      imports INT
@@ -7,6 +19,7 @@ module CPP-EXECUTION-STMT-BLOCK
      imports CPP-BUILTIN-SYNTAX
      imports CPP-DYNAMIC-SYNTAX
      imports CPP-EXECUTION-ENV-SYNTAX
+     imports CPP-EXECUTION-STMT-BLOCK-SYNTAX
      imports CPP-SYMLOC-SYNTAX
      imports CPP-SYNTAX
      imports CPP-CLASS-BASIC-SYNTAX
@@ -54,19 +67,19 @@ module CPP-EXECUTION-STMT-BLOCK
           [structural]
 
      syntax Set ::= getLocalAddresses() [function]
-                  | #getLocalAddresses(List, Set)
+                  | #getLocalAddresses(List, Set) [function]
 
      rule [[ getLocalAddresses() => #getLocalAddresses(LC, .Set) ]]
           <locally-constructed> LC::List </locally-constructed>
 
      rule #getLocalAddresses(.List, S::Set) => S
      rule #getLocalAddresses(
-               (ListItem(ktriple(lv(Loc::SymLoc, _, _), _, _)) => .List) _,
+               (ListItem(lcentry(lv(Loc::SymLoc, _, _), _, _, _)) => .List) _,
                (.Set => SetItem(baseOfLoc(Loc))) _
           )
 
      rule <k> addToConstructed(L:LVal, t(... st: classType(...)) #as T::CPPType) => .K ...</k>
-          <locally-constructed> .List => ListItem(ktriple(L, false, false)) ...</locally-constructed>
+          <locally-constructed> .List => ListItem(lcentry(L, true, false, false)) ...</locally-constructed>
 
      rule (.K => addToConstructed(L [ prv(N -Int 1, noTrace, type(size_t)) ], T))
           ~> addToConstructed(L:LVal, t(... st: arrayType(T::CPPType, N::Int => N -Int 1)))
@@ -86,17 +99,18 @@ module CPP-EXECUTION-STMT-BLOCK
      rule <k> destructLocals(...) => .K ...</k>
           <locally-constructed> .List </locally-constructed>
 
-     syntax KItem ::= destructLocal(isException: Bool, entry: KTuple)
+     syntax KItem ::= destructLocal(isException: Bool, entry: KItem)
 
      rule destructLocal(IsException:Bool,
-               ktriple(
+               lcentry(
                     lv(Loc::SymLoc, _, _) #as V::LVal,
+                    Initialized:Bool,
                     CanBeVirtual::Bool,
                     IsConstructor:Bool
                )
           )
           =>
-          #if IsConstructor andBool notBool IsException #then
+          #if notBool Initialized orBool (IsConstructor andBool notBool IsException) #then
                .K
           #else
                destruct(V, CanBeVirtual) ~> fullExpression

--- a/semantics/cpp/language/execution/stmt/block.k
+++ b/semantics/cpp/language/execution/stmt/block.k
@@ -75,7 +75,7 @@ module CPP-EXECUTION-STMT-BLOCK
      rule #getLocalAddresses(.List, S::Set) => S
      rule #getLocalAddresses(
                (ListItem(lcentry(lv(Loc::SymLoc, _, _), _, _, _)) => .List) _,
-               (.Set => SetItem(baseOfLoc(Loc))) _
+               (.Set => SetItem(base(Loc))) _
           )
 
      rule <k> addToConstructed(L:LVal, t(... st: classType(...)) #as T::CPPType) => .K ...</k>
@@ -119,7 +119,7 @@ module CPP-EXECUTION-STMT-BLOCK
           #if IsConstructor #then
                .K
           #else
-               deleteObject(baseOfLoc(Loc))
+               deleteObject(base(Loc))
           #fi
 
      syntax KItem ::= "unfoldBlockStack"

--- a/semantics/cpp/language/execution/stmt/return.k
+++ b/semantics/cpp/language/execution/stmt/return.k
@@ -58,8 +58,7 @@ module CPP-EXECUTION-STMT-RETURN
           <block-history> ListItem(_) ...</block-history>
           <block-stack> ListItem(_) ...</block-stack>
 
-     rule <k> Return''(V:Val) => fullExpression ~> destructLocals(false) ~> deleteObjects(Locals) ~> return(V) ...</k>
-          <local-addresses> Locals::Set </local-addresses>
+     rule <k> Return''(V:Val) => fullExpression ~> destructLocals(false) ~> return(V) ...</k>
           <block-history> .List </block-history>
           <block-stack> .List </block-stack>
 

--- a/semantics/cpp/language/execution/stmt/try.k
+++ b/semantics/cpp/language/execution/stmt/try.k
@@ -63,11 +63,10 @@ module CPP-EXECUTION-STMT-TRY
      syntax KItem ::= "unwindFunction" | tryMark(Int)
 
      // delete locals when function body is not wrapped in Block
-     rule <k> (.K => destructLocals(true) ~> deleteObjects(S)) ~> unwindFunction ...</k>
+     rule <k> (.K => destructLocals(true)) ~> unwindFunction ...</k>
           <block-stack> .List </block-stack>
-          <local-addresses> S::Set => .Set </local-addresses>
           <locally-constructed> L::List </locally-constructed>
-          requires size(S) >Int 0 orBool size(L) >Int 0
+          requires size(L) >Int 0
 
      rule <k> unwindFunction ~> throw(V::LVal) ~> _
               => exitRestrictBlock(.Set)
@@ -79,7 +78,6 @@ module CPP-EXECUTION-STMT-TRY
                <curr-scope> blockScope(_, Base::SymBase, _) </curr-scope>
                <live-va-lists> .Set </live-va-lists>
                <block-control>...
-                    <local-addresses> .Set </local-addresses>
                     <locally-constructed> .List </locally-constructed>
                ...</block-control>
                <block-stack> .List </block-stack>
@@ -107,7 +105,7 @@ module CPP-EXECUTION-STMT-TRY
      rule <k> (.K => catchAndCallTerminate) ~> unwindFunction ~> throw(V::LVal) ...</k>
           <curr-scope> blockScope(_, Base::SymBase, _) </curr-scope>
           <functions>... Base |-> functionObject(_, FuncT::CPPType, _, _) ...</functions>
-          <local-addresses> .Set </local-addresses>
+          <locally-constructed> .List </locally-constructed>
           requires notBool canThrowException(FuncT, type(V)) andBool notBool isDynamicExceptionSpec(FuncT)
 
      // TODO(dwightguth): call std::unexpected if isDynamicExceptionSpec


### PR DESCRIPTION
The cell `<local-addresses>` is no longer used
in the C++ semantics.