### PR TITLE
Make size_t => unsigned-long

### DIFF
--- a/profiles/x86-gcc-limited-libc/semantics/cpp-settings.k
+++ b/profiles/x86-gcc-limited-libc/semantics/cpp-settings.k
@@ -7,8 +7,8 @@ module CPP-SETTINGS
      rule underlyingType(char32_t) => unsigned
      rule underlyingType(wchar_t) => int
 
-     rule size_t => unsigned
-     rule ptrdiff_t => int
+     rule size_t => unsigned-long
+     rule ptrdiff_t => long
 
      rule cfg:refsize => 4
      rule cfg:memberDataPtrSize => 4

--- a/tests/unit-pass/Makefile
+++ b/tests/unit-pass/Makefile
@@ -18,9 +18,7 @@ OS_EXCLUDES := $(OS_STDIO_EXCLUDES) \
                ./991112-1.c \
                ./string-opt-5.c \
                ./inst-check.c \
-               ./include-time.C \
-               ./new23.C \
-               ./new41.C
+               ./include-time.C
 TESTS := $(filter-out $(EXCLUDES), $(filter-out %-link2.c, $(filter-out %-link2.C, ${TUS})))
 OS_TESTS := $(filter-out $(OS_EXCLUDES), $(filter-out $(EXCLUDES), $(filter-out %-link2.c, $(filter-out %-link2.C, ${TUS}))))
 CPP_TESTS := $(filter-out %.c, ${TESTS})


### PR DESCRIPTION
On my machine, there is a problem with the `new41.C` test. The test uses the `__SIZE_TYPE__` macro, that evaluates to `unsigned long`. Having `size_t => unsigned` in the semantics results in having two overloads for `operator new`, the implicit one with an `unsigned` parameter and the user-defined one with `unsigned long`, and the implicit one gets selected.