### PR TITLE
Fix git clone command for docker installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@ dependencies:
 - Install docker (see <https://docs.docker.com/get-started/>)
 - Clone this repository:
   ```sh
-  git clone git@github.com:kframework/c-semantics
+  git clone https://github.com/kframework/c-semantics.git
   cd c-semantics
   git submodule update --init --recursive
   ```


### PR DESCRIPTION
The git command to clone the project is wrong - it uses checkout via ssh instead of HTTP.  Thus, it will fail, except for the project maintainers I guess...