### PR TITLE
Clever linking

### DIFF
--- a/semantics/c/language/execution/init.k
+++ b/semantics/c/language/execution/init.k
@@ -10,7 +10,6 @@ module C-EXECUTION-INIT-SYNTAX
      syntax KItem ::= "initMainThread'" "(" String ")"
      syntax KItem ::= "callAtExit" | "callAtQuickExit"
      syntax RValue ::= "NullPointerConstant" [function]
-     syntax String ::= getEntryPoint(Set) [function]
 endmodule
 
 module C-EXECUTION-INIT
@@ -199,9 +198,6 @@ module C-EXECUTION-INIT
           <types>... Identifier(EP) |-> T::Type ...</types>
           <status> _ => mainCalled </status>
           [ndtrans]
-
-     rule getEntryPoint(_ SetItem(EntryPoint(EP::String))) => EP
-     rule getEntryPoint(_) => "main" [owise]
 
      // int main(void) -- also, int main() gets normalized to main(void)
      syntax K ::= #callEntryPoint(String, Int, KItem, Type) [function]

--- a/semantics/c/language/translation/configuration.k
+++ b/semantics/c/language/translation/configuration.k
@@ -89,6 +89,8 @@ module C-CONFIGURATION
                .K
           </decl-type-holder>
      </init-calc>
+
+     <do-not-record-linking-deps> false </do-not-record-linking-deps>
 </exec>
 
 <error-cell multiplicity="?" color="black"> .K </error-cell>

--- a/semantics/c/language/translation/expr/identifier.k
+++ b/semantics/c/language/translation/expr/identifier.k
@@ -9,7 +9,13 @@ module C-EXPR-IDENTIFIER
      imports C-SYMLOC-SYNTAX
      imports C-TYPING-SYNTAX
 
-     rule <k> X:CId => lv(lnew(Base), T) ...</k>
+     rule <k> X:CId =>
+              #if isRestrictType(T) #then
+                lv(restrictedNew(Base, getRestrictBlock(T)), T)
+              #else
+                lv(lnew(Base), T)
+              #fi
+          ...</k>
           <env>... X |-> Base:DirectBase ...</env>
           <types>... X |-> T::Type ...</types>
           <curr-tu> Tu::String </curr-tu>
@@ -17,20 +23,9 @@ module C-EXPR-IDENTIFIER
           <uses>... .Set => SetItem(X) ...</uses>
           <enums> Enums::Map </enums>
           requires Base =/=K nonStatic
-               andBool notBool isRestrictType(T)
                andBool notBool X in_keys(Enums)
           [structural]
-     rule <k> X:CId => lv(restrictedNew(Base, getRestrictBlock(T)), T) ...</k>
-          <env>... X |-> Base:DirectBase ...</env>
-          <types>... X |-> T::Type ...</types>
-          <curr-tu> Tu::String </curr-tu>
-          <tu-id> Tu </tu-id>
-          <uses>... .Set => SetItem(X) ...</uses>
-          <enums> Enums::Map </enums>
-          requires Base =/=K nonStatic
-               andBool isRestrictType(T)
-               andBool notBool X in_keys(Enums)
-          [structural]
+
      rule <k> X:CId => le(X, T) ...</k>
           <env>... X |-> nonStatic ...</env>
           <types>... X |-> T::Type ...</types>

--- a/semantics/c/language/translation/expr/identifier.k
+++ b/semantics/c/language/translation/expr/identifier.k
@@ -8,6 +8,14 @@ module C-EXPR-IDENTIFIER
      imports C-MEMORY-READING-SYNTAX
      imports C-SYMLOC-SYNTAX
      imports C-TYPING-SYNTAX
+     imports COMMON-LINKING-DEPS-SYNTAX
+
+     syntax LinkdepNode ::= currentLinkdepNode() [function]
+
+     rule [[currentLinkdepNode() => linkdepNodeFromCId(X)]]
+          <curr-scope> blockScope(... functionId: X::CId) </curr-scope>
+
+     rule currentLinkdepNode() => notAFunction() [owise]
 
      rule <k> X:CId =>
               #if isRestrictType(T) #then
@@ -20,7 +28,18 @@ module C-EXPR-IDENTIFIER
           <types>... X |-> T::Type ...</types>
           <curr-tu> Tu::String </curr-tu>
           <tu-id> Tu </tu-id>
+          <externals> Exts </externals>
+          <internals> Ints </internals>
+          <linking-deps> Deps::Map
+          => #if Flag #then Deps #else
+               #if X in_keys(Exts) orBool X in_keys(Ints) #then
+                    updateLinkdep(Deps, currentLinkdepNode(), linkdepNodeFromCId(X), L)
+               #else Deps #fi
+             #fi
+          </linking-deps>
+          <do-not-record-linking-deps> Flag:Bool </do-not-record-linking-deps>
           <uses>... .Set => SetItem(X) ...</uses>
+          <curr-program-loc> L:CabsLoc </curr-program-loc>
           <enums> Enums::Map </enums>
           requires Base =/=K nonStatic
                andBool notBool X in_keys(Enums)
@@ -45,6 +64,12 @@ module C-EXPR-IDENTIFIER
           <tu-id> Tu </tu-id>
           <externals>... X |-> _ ...</externals>
           <external-uses> Uses::Map => Uses[X <- L] </external-uses>
+          <linking-deps> Deps::Map
+          => #if Flag #then Deps #else
+               updateLinkdep(Deps, currentLinkdepNode(), linkdepNodeFromCId(X), L)
+             #fi
+          </linking-deps>
+          <do-not-record-linking-deps> Flag:Bool </do-not-record-linking-deps>
           <uses>... .Set => SetItem(X) ...</uses>
           <curr-program-loc> L:CabsLoc </curr-program-loc>
           <enums> Enums::Map </enums>

--- a/semantics/c/language/translation/function-def.k
+++ b/semantics/c/language/translation/function-def.k
@@ -31,11 +31,26 @@ module C-FUNCTION-DEF
      imports C-TYPING-COMMON-SYNTAX
      imports C-TYPING-SYNTAX
 
+     // we need to ensure that the use of &X in the function definition
+     // does not count as linking dependency
+     syntax KItem ::= doNotRecordLinkingDeps(KItem)
+                    | #doNotRecordLinkingDeps()
+
+     rule <k> doNotRecordLinkingDeps(X::KItem)
+          => X ~> #doNotRecordLinkingDeps()
+          ...</k>
+          <do-not-record-linking-deps> false => true </do-not-record-linking-deps>
+
+     rule <k> (X:KResult ~> #doNotRecordLinkingDeps())
+          => X
+          ...</k>
+          <do-not-record-linking-deps> true => false </do-not-record-linking-deps>
+
      rule FunctionDefinition(typedDeclaration(t(... st: functionType(...)) #as T::Type, X:CId), Blk:KItem)
           => declare'(
                typedDeclaration(toPrototype(emptyToVoid(T)), X),
                initializer(initFunction(
-                    &(X),
+                    doNotRecordLinkingDeps(&(X)),
                     X,
                     // The return and parameter types from the definition.
                     t(getQualifiers(T), getModifiers(T), functionType(utype(elideDeclParams(innerType(T))),
@@ -146,7 +161,7 @@ module C-FUNCTION-DEF
      rule isArgvType(_) => false [owise]
 
      rule <k> initFunction(tv(Loc:SymLoc, T::UType), X:CId, DefT::Type) => .K ...</k>
-          <elab>... .K => initFunction(&(X), X, DefT) </elab>
+          <elab>... .K => initFunction(doNotRecordLinkingDeps(&(X)), X, DefT) </elab>
           requires isLinkerLoc(Loc)
      rule <k> initFunction(tv(Loc:SymLoc, ut(_, pointerType(t(... st: functionType(...))))), X::CId, DefT::Type)
                => .K

--- a/semantics/common/common.k
+++ b/semantics/common/common.k
@@ -5,6 +5,7 @@ require "compat.k"
 require "configuration.k"
 require "error.k"
 require "init.k"
+require "linking-deps.k"
 require "memory.k"
 require "options.k"
 require "settings.k"
@@ -17,6 +18,7 @@ module COMMON
      imports BITS
      imports COMMON-BUILTIN
      imports COMMON-INIT
+     imports COMMON-LINKING-DEPS
      imports COMMON-TRANSLATION-UNIT
      imports COMPAT
      imports ERROR

--- a/semantics/common/configuration.k
+++ b/semantics/common/configuration.k
@@ -34,6 +34,8 @@ module COMMON-CONFIGURATION
           <external-decls-loc> .Map </external-decls-loc>
           // CIds |-> CabsLoc
           <external-uses> .Map </external-uses>
+          // linkdepNode |-> (linkdepNode |-> CabsLoc)
+          <linking-deps> .Map </linking-deps>
           // CId |-> CabsLoc
           <external-defs-loc> .Map </external-defs-loc>
           // SymBase |-> Set(ktriple(TU, QualId, Type))

--- a/semantics/common/init.k
+++ b/semantics/common/init.k
@@ -1,6 +1,7 @@
 module COMMON-INIT-SYNTAX
      imports BASIC-K
      imports STRING
+     imports SET
 
      syntax KItem ::= loadObj(K)
      // this takes input from a file which is not split by thread, so we don't want to split this rule.
@@ -9,6 +10,8 @@ module COMMON-INIT-SYNTAX
      syntax CId ::= "mainArguments"
 
      syntax KItem ::= removeUnusedIdentifiers(tu: String)
+
+     syntax String ::= getEntryPoint(Set) [function]
 endmodule
 
 module COMMON-INIT
@@ -18,6 +21,9 @@ module COMMON-INIT
      imports K-EQUAL
      imports OPTIONS-SYNTAX
      imports COMMON-TRANSLATION-UNIT-SYNTAX
+
+     rule getEntryPoint(_ SetItem(EntryPoint(EP::String))) => EP
+     rule getEntryPoint(_) => "main" [owise]
 
      rule <k> loadObj(G:GlobalCell) => .K ...</k>
           (<global> _ </global> => G)

--- a/semantics/common/linking-deps.k
+++ b/semantics/common/linking-deps.k
@@ -1,0 +1,55 @@
+module COMMON-LINKING-DEPS-SYNTAX
+
+     // forward declarations
+     syntax String
+     syntax Map
+     syntax CId
+     syntax CabsLoc
+
+     syntax InternalOrExternal ::= internal(String) | external()
+     syntax LinkdepNode ::= linkdepNode(CId, InternalOrExternal)
+                          | linkdepNodeFromCId(CId) [function]
+
+     syntax Map ::= updateLinkdep(Map, LinkdepNode, LinkdepNode, CabsLoc) [function]
+
+
+     // TODO
+     syntax Map ::= mergeLinkdep(Map, Map) [function]
+
+endmodule
+
+module COMMON-LINKING-DEPS
+     imports COMMON-LINKING-DEPS-SYNTAX
+     imports DOMAINS
+     imports C-CONFIGURATION
+
+     // The maps have the following form:
+     // linkdepNode |-> (linkdepNode |-> CabsLoc)
+
+     rule updateLinkdep(M::Map, From::LinkdepNode, To::LinkdepNode, Where::CabsLoc)
+       => M [From <- ((M [ From ] orDefault .Map)[To <- Where])]
+
+
+     rule mergeLinkdep(M1, .Map) => M1
+
+     // generally, the keys of two maps will be independent,
+     // since keys corresponds to function definition
+     // and every function may be defined only once.
+     // But for C++, we want a special not-a-function key corresponding
+     // to situations where a symbol is used from outside a function,
+     // e.g. from the global namespace.
+     rule mergeLinkdep(M1, M2)
+          => (From => mergeLinkdep(
+               M1[From <- updateMap(M1[From] orDefault .Map, M2[From])],
+               M2[From <- undef])
+             )(choice(M2))
+
+     // but what if the rule in global fires earlier than when externals/internals are filled?
+     rule [[linkdepNodeFromCId(X) => linkdepNode(X, external())]]
+          <externals>... X |-> _ ...</externals>
+     rule [[linkdepNodeFromCId(X) => linkdepNode(X, internal(TU))]]
+          <internals>... X |-> _ ...</internals>
+          <curr-tu> TU::String </curr-tu>
+
+
+endmodule

--- a/semantics/common/linking-deps.k
+++ b/semantics/common/linking-deps.k
@@ -8,12 +8,11 @@ module COMMON-LINKING-DEPS-SYNTAX
 
      syntax InternalOrExternal ::= internal(String) | external()
      syntax LinkdepNode ::= linkdepNode(CId, InternalOrExternal)
+                          | notAFunction()
                           | linkdepNodeFromCId(CId) [function]
 
      syntax Map ::= updateLinkdep(Map, LinkdepNode, LinkdepNode, CabsLoc) [function]
 
-
-     // TODO
      syntax Map ::= mergeLinkdep(Map, Map) [function]
 
 endmodule
@@ -27,7 +26,7 @@ module COMMON-LINKING-DEPS
      // linkdepNode |-> (linkdepNode |-> CabsLoc)
 
      rule updateLinkdep(M::Map, From::LinkdepNode, To::LinkdepNode, Where::CabsLoc)
-       => M [From <- ((M [ From ] orDefault .Map)[To <- Where])]
+       => M [From <- ({M [ From ] orDefault .Map}:>Map[To <- Where])]
 
 
      rule mergeLinkdep(M1, .Map) => M1
@@ -37,12 +36,14 @@ module COMMON-LINKING-DEPS
      // and every function may be defined only once.
      // But for C++, we want a special not-a-function key corresponding
      // to situations where a symbol is used from outside a function,
-     // e.g. from the global namespace.
+     // e.g. from the global namespace, and this key may be present
+     // in both maps.
      rule mergeLinkdep(M1, M2)
-          => (From => mergeLinkdep(
-               M1[From <- updateMap(M1[From] orDefault .Map, M2[From])],
+          => #fun(From => mergeLinkdep(
+               M1[From <- updateMap({M1[From] orDefault .Map}:>Map, {M2[From]}:>Map)],
                M2[From <- undef])
              )(choice(M2))
+          requires size(M2) >=Int 1
 
      // but what if the rule in global fires earlier than when externals/internals are filled?
      rule [[linkdepNodeFromCId(X) => linkdepNode(X, external())]]
@@ -50,6 +51,5 @@ module COMMON-LINKING-DEPS
      rule [[linkdepNodeFromCId(X) => linkdepNode(X, internal(TU))]]
           <internals>... X |-> _ ...</internals>
           <curr-tu> TU::String </curr-tu>
-
 
 endmodule

--- a/semantics/common/linking-deps.k
+++ b/semantics/common/linking-deps.k
@@ -31,10 +31,10 @@ module COMMON-LINKING-DEPS
 
      rule mergeLinkdep(M1, .Map) => M1
 
-     // generally, the keys of two maps will be independent,
-     // since keys corresponds to function definition
+     // Generally, the keys of two maps will be independent,
+     // since keys corresponds to function definitions
      // and every function may be defined only once.
-     // But for C++, we want a special not-a-function key corresponding
+     // However, for C++ we want a special not-a-function key corresponding
      // to situations where a symbol is used from outside a function,
      // e.g. from the global namespace, and this key may be present
      // in both maps.
@@ -45,7 +45,8 @@ module COMMON-LINKING-DEPS
              )(choice(M2))
           requires size(M2) >=Int 1
 
-     // but what if the rule in global fires earlier than when externals/internals are filled?
+     // But what if the rule in global fires earlier than when
+     // externals/internals are filled?
      rule [[linkdepNodeFromCId(X) => linkdepNode(X, external())]]
           <externals>... X |-> _ ...</externals>
      rule [[linkdepNodeFromCId(X) => linkdepNode(X, internal(TU))]]

--- a/semantics/linking/c-resolution.k
+++ b/semantics/linking/c-resolution.k
@@ -1,7 +1,9 @@
 module LINKING-C-RESOLUTION-SYNTAX
      imports MAP
 
-     syntax KItem ::= resolveCReferences(Map)
+     syntax LinkErrorHandling ::= "linkErrors" | "linkWarnings"
+
+     syntax KItem ::= resolveCReferences(Map, LinkErrorHandling)
                     | "resolveMain"
 endmodule
 
@@ -16,15 +18,21 @@ module LINKING-C-RESOLUTION
      imports ERROR-SYNTAX
      imports SYMLOC-SYNTAX
 
+     syntax KItem ::= errorRecovery(LinkErrorHandling, KItem, KItem) [function, functional]
+     rule errorRecovery(linkErrors, _, OnError:KItem) => OnError
+     rule errorRecovery(linkWarnings, OnWarning:KItem, _) => OnWarning
+
      // Add the real location at which an external reference is defined to the
      // environment of every TU where it appears.
 
-     syntax KItem ::= resolveCReference(CId)
-     rule (.K => setTranslationLoc(L) ~> resolveCReference(X))
-               ~> resolveCReferences((X:CId |-> L:CabsLoc => .Map) _)
+     syntax KItem ::= resolveCReference(CId, LinkErrorHandling)
+     rule (.K => setTranslationLoc(L) ~> resolveCReference(X, ErrorHandling))
+               ~> resolveCReferences(
+                    (X:CId |-> L:CabsLoc => .Map) _,
+                    ErrorHandling::LinkErrorHandling)
           [structural]
 
-     rule <k> resolveCReference(X:CId) ...</k>
+     rule <k> resolveCReference(X:CId, _) ...</k>
           <external-decls>...
                X |-> (SetItem(Tu:String) => .Set) _::Set
           ...</external-decls>
@@ -33,7 +41,7 @@ module LINKING-C-RESOLUTION
           <genv>... X |-> (Base:LinkBase => Base') ...</genv>
           <linkings>... .Map => Base |-> Base' ...</linkings>
           [structural]
-     rule <k> resolveCReference(X:CId) ...</k>
+     rule <k> resolveCReference(X:CId, _) ...</k>
           <external-decls>...
                X |-> (SetItem(Tu:String) => .Set) _::Set
           ...</external-decls>
@@ -41,35 +49,39 @@ module LINKING-C-RESOLUTION
           <tu-id> Tu </tu-id>
           <genv>... X |-> Base:DirectBase ...</genv>
           [structural]
-     rule <k> resolveCReference(X:CId) => .K  ...</k>
+     rule <k> resolveCReference(X:CId, _) => .K  ...</k>
           <external-decls>...
                X:CId |-> .Set => .Map
           ...</external-decls>
           <external-defs>... X |-> _ ...</external-defs>
           <external-types>... X |-> _ ...</external-types>
           [structural]
-     rule <k> resolveCReference(X:CId) => .K ...</k>
+     rule <k> resolveCReference(X:CId, _) => .K ...</k>
           <external-defs> Defs:Map </external-defs>
           <external-types> Types:Map </external-types>
           requires (notBool (X in_keys(Defs)) orBool notBool (X in_keys(Types)))
                andBool isMangledName(X)
           [structural]
-     rule <k> (.K => setTranslationLoc(L) ~> EXT-UNDEF("TDR2",
-                    "No definition for symbol with external linkage: "
-                     +String showCId(X) +String "."))
-              ~> resolveCReference(X:CId)
-          ...</k>
+     rule <k>  (resolveCReference(X:CId, ErrorHandling::LinkErrorHandling) => setTranslationLoc(L)
+                    ~> EXT-UNDEF("TDR2",
+                         "No definition for symbol with external linkage: "
+                         +String showCId(X) +String ".")
+                    ~> errorRecovery(
+                         ErrorHandling,
+                         recoverFromError(.K),
+                         resolveCReference(X:CId, ErrorHandling))
+               )
+               ...
+          </k>
           <external-defs> Defs:Map </external-defs>
           <external-types> Types:Map </external-types>
-          <external-decls-loc>...
-               X |-> L::CabsLoc
-          ...</external-decls-loc>
+          <external-decls-loc>... X |-> L::CabsLoc ...</external-decls-loc>
           requires (notBool (X in_keys(Defs)) orBool notBool (X in_keys(Types)))
                andBool notBool isMangledName(X)
           [structural]
      // Now everything left in <external-uses> should be an unresolved
      // reference.
-     rule resolveCReferences(.Map) => .K
+     rule resolveCReferences(.Map, _) => .K
 
      syntax Bool ::= isMangledName(CId) [function]
      rule isMangledName(Identifier(X::String)) => substrString(X, 0, 2) ==String "_Z"

--- a/semantics/linking/c-resolution.k
+++ b/semantics/linking/c-resolution.k
@@ -79,7 +79,6 @@ module LINKING-C-RESOLUTION
      // Remember which TU has the definition of main.
      rule <k> resolveMain => .K ...</k>
           <main-tu>... .Set => SetItem(MainTu) </main-tu>
-          (<linking-state>... .Bag ...</linking-state> => .Bag)
           <external-defs>...
                Identifier("main") |-> (obj(... d: static(MainTu:String)) #as Main::SymBase)
           ...</external-defs>

--- a/semantics/linking/configuration.k
+++ b/semantics/linking/configuration.k
@@ -1,5 +1,6 @@
 module C-CONFIGURATION
      imports LINKING-INIT-SYNTAX
+     imports COMMON-INIT-SYNTAX
      imports COMMON-CONFIGURATION
      imports DEFAULT-STRATEGY
      imports CPP-DYNAMIC-SYNTAX
@@ -17,7 +18,7 @@ module C-CONFIGURATION
 <exec>
      <k color="green">
           load($OBJS:K)
-          ~> link
+          ~> linkProgram(getEntryPoint($OPTIONS:Set))
           ~> cleanup
      </k>
 

--- a/semantics/linking/cpp-resolution.k
+++ b/semantics/linking/cpp-resolution.k
@@ -102,7 +102,6 @@ module LINKING-CPP-RESOLUTION
 
      rule <k> resolveMain => .K ...</k>
           <main-tu>... (.Set => SetItem(MainTu)) </main-tu>
-          (<linking-state>... .Bag ...</linking-state> => .Bag)
           <odr-defs>... GlobalNamespace() :: Identifier("main") |-> (_::CPPType |-> (_, obj(... d: static(MainTu:String)))) ...</odr-defs>
 
      // TODO(dwightguth): make this a better error message when we take the C++ semantics live

--- a/semantics/linking/cpp-resolution.k
+++ b/semantics/linking/cpp-resolution.k
@@ -2,6 +2,8 @@ module LINKING-CPP-RESOLUTION-SYNTAX
      imports SET
 
      syntax KItem ::= resolveCPPReferences(Set)
+     syntax Bool ::= hasCPPMain() [function]
+
 endmodule
 
 module LINKING-CPP-RESOLUTION
@@ -99,6 +101,11 @@ module LINKING-CPP-RESOLUTION
           ...</k>
           <odr-decls> Decls::Map </odr-decls>
           requires notBool OdrBase in_keys(Decls)
+
+     rule [[ hasCPPMain() => true ]]
+          <odr-defs>... GlobalNamespace() :: Identifier("main") |-> _ ...</odr-defs>
+
+     rule hasCPPMain() => false [owise]
 
      rule <k> resolveMain => .K ...</k>
           <main-tu>... (.Set => SetItem(MainTu)) </main-tu>

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -74,7 +74,7 @@ module LINKING-INIT
           ~> addCppBuiltins(weakCppBuiltins, false)
           ~> removeUnusedIdentifiers(Tu)
 
-     // returns a map from
+     // Returns a map from LinkdepNode to CabsLoc
      syntax Map ::= reachableSymbols(entrypoint: String) [function]
                   | #reachableSymbols(Map, Map) [function]
 
@@ -117,14 +117,18 @@ module LINKING-INIT
                => resolveMain
                ~> resolveCPPReferences(OdrUses)
                ~> #if hasCPPMain() #then
-                    resolveCReferences(Uses)
+                    resolveCReferences(Uses, linkErrors)
                   #else
-                    resolveCReferences(onlyExternal(reachableSymbols(Entrypoint))[Identifier(Entrypoint) <- undef])
+                    #fun (Reachable =>
+                         resolveCReferences(Reachable[Identifier(Entrypoint) <- undef], linkErrors)
+                         ~> resolveCReferences(removeAll(Uses, keys(Reachable))[Identifier(Entrypoint) <- undef], linkWarnings)
+                    )(onlyExternal(reachableSymbols(Entrypoint)))
                   #fi
                ~> clearLinkingState()
           ...</k>
           <odr-uses> OdrUses::Set => .Set </odr-uses>
           <external-uses> Uses::Map => .Map </external-uses>
+          <linking-deps> Deps </linking-deps>
 
      syntax KItem ::= clearLinkingState()
      rule <k> clearLinkingState() => .K ...</k>

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -72,10 +72,45 @@ module LINKING-INIT
           ~> addCppBuiltins(weakCppBuiltins, false)
           ~> removeUnusedIdentifiers(Tu)
 
+     // returns a map from
+     syntax Map ::= reachableSymbols() [function]
+                  | #reachableSymbols(Map, Map) [function]
+
+     rule reachableSymbols()
+          => #reachableSymbols(.Map, linkdepNode(Identifier("main"), external()) |-> UnknownCabsLoc)
+
+     rule #reachableSymbols(Result, .Map) => Result
+
+     rule [[ #reachableSymbols(Result::Map, M::Map)
+          => #fun(Curr =>
+               #reachableSymbols(
+                    Result[Curr <- M[Curr]],
+                    removeAll(updateMap(M, {Deps[Curr] orDefault .Map}:>Map), keys(Result) SetItem(Curr))
+               )
+             )(choice(M)) ]]
+          <linking-deps> Deps </linking-deps>
+          requires size(M) >=Int 1
+
+     syntax Map ::= onlyExternal(Map) [function]
+
+     rule onlyExternal(.Map) => .Map
+
+     rule onlyExternal(M::Map)
+          => #fun (Curr =>
+               #if linkdepNode(_, external()) :=K Curr #then
+                 linkdepNodeId(Curr) |-> M[Curr]
+               #else .Map #fi
+               onlyExternal(M[Curr <- undef])
+             )(choice(M))
+          requires size(M) >=Int 1
+
+     syntax CId ::= linkdepNodeId(LinkdepNode) [function]
+     rule linkdepNodeId(linkdepNode(X, _)) => X
+
      syntax KItem ::= "resolveReferences"
      rule <k> resolveReferences
                => resolveCPPReferences(OdrUses)
-               ~> resolveCReferences(Uses)
+               ~> resolveCReferences(onlyExternal(reachableSymbols()))
                ~> resolveMain
           ...</k>
           <odr-uses> OdrUses::Set => .Set </odr-uses>

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -15,6 +15,7 @@ module LINKING-INIT
      imports C-TYPING-SORTS
      imports COMMON-BUILTIN-SYNTAX
      imports COMMON-INIT-SYNTAX
+     imports COMMON-LINKING-DEPS-SYNTAX
      imports COMMON-TRANSLATION-UNIT-SYNTAX
      imports COMPAT-SYNTAX
      imports ERROR-SYNTAX
@@ -191,6 +192,7 @@ module LINKING-INIT
                     <external-decls> ExtDecls1:Map </external-decls>
                     <external-decls-loc> ExtDeclsLoc1:Map </external-decls-loc>
                     <external-uses> ExtUses1:Map </external-uses>
+                    <linking-deps> Linkdep1 </linking-deps>
                     <external-defs-loc> ExtDefsLoc1:Map </external-defs-loc>
                     <odr-decls> OdrDecls1:Map </odr-decls>
                     <odr-uses> OdrUses1:Set </odr-uses>
@@ -220,6 +222,7 @@ module LINKING-INIT
                     <external-decls> ExtDecls2:Map </external-decls>
                     <external-decls-loc> ExtDeclsLoc2:Map </external-decls-loc>
                     <external-uses> ExtUses2:Map </external-uses>
+                    <linking-deps> Linkdep2 </linking-deps>
                     <external-defs-loc> ExtDefsLoc2:Map </external-defs-loc>
                     <odr-decls> OdrDecls2:Map </odr-decls>
                     <odr-uses> OdrUses2:Set </odr-uses>
@@ -254,6 +257,7 @@ module LINKING-INIT
                     <external-decls> mergeDecls(ExtDecls1, ExtDecls2) </external-decls>
                     <external-decls-loc> updateMap(ExtDeclsLoc1, ExtDeclsLoc2) </external-decls-loc>
                     <external-uses> updateMap(ExtUses1, ExtUses2) </external-uses>
+                    <linking-deps> mergeLinkdep(Linkdep1, Linkdep2) </linking-deps>
                     <external-defs-loc> updateMap(ExtDefsLoc1, ExtDefsLoc2) </external-defs-loc>
                     <odr-decls> mergeDecls(OdrDecls1, OdrDecls2) </odr-decls>
                     <odr-uses> OdrUses1 OdrUses2 </odr-uses>

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -119,7 +119,7 @@ module LINKING-INIT
                ~> #if hasCPPMain() #then
                     resolveCReferences(Uses)
                   #else
-                    resolveCReferences(onlyExternal(reachableSymbols(Entrypoint))[Entrypoint <- undef])
+                    resolveCReferences(onlyExternal(reachableSymbols(Entrypoint))[Identifier(Entrypoint) <- undef])
                   #fi
                ~> clearLinkingState()
           ...</k>

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -110,7 +110,11 @@ module LINKING-INIT
      syntax KItem ::= "resolveReferences"
      rule <k> resolveReferences
                => resolveCPPReferences(OdrUses)
-               ~> resolveCReferences(onlyExternal(reachableSymbols()))
+               ~> #if hasCPPMain() #then
+                    resolveCReferences(Uses)
+                  #else
+                    resolveCReferences(onlyExternal(reachableSymbols()))
+                  #fi
                ~> resolveMain
                ~> clearLinkingState()
           ...</k>

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -112,9 +112,14 @@ module LINKING-INIT
                => resolveCPPReferences(OdrUses)
                ~> resolveCReferences(onlyExternal(reachableSymbols()))
                ~> resolveMain
+               ~> clearLinkingState()
           ...</k>
           <odr-uses> OdrUses::Set => .Set </odr-uses>
           <external-uses> Uses::Map => .Map </external-uses>
+
+     syntax KItem ::= clearLinkingState()
+     rule <k> clearLinkingState() => .K ...</k>
+          (<linking-state>... .Bag ...</linking-state> => .Bag)
 
      syntax KItem ::= makeNs(tu: String, Namespace)
      rule <k> makeNs(Tu::String, N::Namespace) => .K ...</k>

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -114,13 +114,13 @@ module LINKING-INIT
 
      syntax KItem ::= resolveReferences(entrypoint: String)
      rule <k> resolveReferences(Entrypoint::String)
-               => resolveCPPReferences(OdrUses)
+               => resolveMain
+               ~> resolveCPPReferences(OdrUses)
                ~> #if hasCPPMain() #then
                     resolveCReferences(Uses)
                   #else
                     resolveCReferences(onlyExternal(reachableSymbols(Entrypoint)))
                   #fi
-               ~> resolveMain
                ~> clearLinkingState()
           ...</k>
           <odr-uses> OdrUses::Set => .Set </odr-uses>

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -1,8 +1,9 @@
 module LINKING-INIT-SYNTAX
      imports BASIC-K
+     imports STRING-SYNTAX
 
      syntax KItem ::= load(K) [symbol]
-     syntax KItem ::= "link"
+     syntax KItem ::= linkProgram(entrypoint: String)
 
 endmodule
 
@@ -32,15 +33,16 @@ module LINKING-INIT
      imports CPP-TYPE-MAP-SYNTAX
      imports SYMLOC-SYNTAX
 
-     rule <k> link
+     rule <k> linkProgram(Entrypoint::String)
                => cBuiltinTu("builtin")
                ~> cppBuiltinTu("cpp-builtin")
                ~> nativeTu("native")
-               ~> resolveReferences
+               ~> resolveReferences(Entrypoint)
                ~> reportSuccess
           ...</k>
           <options>... SetItem(Link()) ...</options>
-     rule <k> link => reportSuccess ...</k>
+
+     rule <k> linkProgram(_) => reportSuccess ...</k>
           <options> Opts::Set </options>
           requires notBool Link() in Opts
 
@@ -73,11 +75,11 @@ module LINKING-INIT
           ~> removeUnusedIdentifiers(Tu)
 
      // returns a map from
-     syntax Map ::= reachableSymbols() [function]
+     syntax Map ::= reachableSymbols(entrypoint: String) [function]
                   | #reachableSymbols(Map, Map) [function]
 
-     rule reachableSymbols()
-          => #reachableSymbols(.Map, linkdepNode(Identifier("main"), external()) |-> UnknownCabsLoc)
+     rule reachableSymbols(Entrypoint::String)
+          => #reachableSymbols(.Map, linkdepNode(Identifier(Entrypoint), external()) |-> UnknownCabsLoc)
 
      rule #reachableSymbols(Result, .Map) => Result
 
@@ -107,13 +109,13 @@ module LINKING-INIT
      syntax CId ::= linkdepNodeId(LinkdepNode) [function]
      rule linkdepNodeId(linkdepNode(X, _)) => X
 
-     syntax KItem ::= "resolveReferences"
-     rule <k> resolveReferences
+     syntax KItem ::= resolveReferences(entrypoint: String)
+     rule <k> resolveReferences(Entrypoint::String)
                => resolveCPPReferences(OdrUses)
                ~> #if hasCPPMain() #then
                     resolveCReferences(Uses)
                   #else
-                    resolveCReferences(onlyExternal(reachableSymbols()))
+                    resolveCReferences(onlyExternal(reachableSymbols(Entrypoint)))
                   #fi
                ~> resolveMain
                ~> clearLinkingState()

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -119,7 +119,7 @@ module LINKING-INIT
                ~> #if hasCPPMain() #then
                     resolveCReferences(Uses)
                   #else
-                    resolveCReferences(onlyExternal(reachableSymbols(Entrypoint)))
+                    resolveCReferences(onlyExternal(reachableSymbols(Entrypoint))[Entrypoint <- undef])
                   #fi
                ~> clearLinkingState()
           ...</k>

--- a/semantics/linking/init.k
+++ b/semantics/linking/init.k
@@ -79,7 +79,10 @@ module LINKING-INIT
                   | #reachableSymbols(Map, Map) [function]
 
      rule reachableSymbols(Entrypoint::String)
-          => #reachableSymbols(.Map, linkdepNode(Identifier(Entrypoint), external()) |-> UnknownCabsLoc)
+          => #reachableSymbols(.Map,
+               (linkdepNode(Identifier(Entrypoint), external()) |-> UnknownCabsLoc)
+               (notAFunction() |-> UnknownCabsLoc)
+               )
 
      rule #reachableSymbols(Result, .Map) => Result
 

--- a/tests/unit-fail-compilation/Makefile
+++ b/tests/unit-fail-compilation/Makefile
@@ -5,7 +5,7 @@ Makefile: $(ROOT)/../check-results.mk ;
 include $(ROOT)/../check-results.mk
 
 TUS := $(wildcard ./*.c) $(wildcard ./*.C)
-EXCLUDES :=
+EXCLUDES := ./link-referenced-not-from-main.c
 TESTS := $(filter-out $(EXCLUDES), $(filter-out %-link2.c, $(filter-out %-link2.C, ${TUS})))
 CPP_TESTS := $(filter-out %.c, ${TESTS})
 C_TESTS := $(filter-out %.C, ${TESTS})

--- a/tests/unit-fail-compilation/link-referenced-from-main-function-ptr.c
+++ b/tests/unit-fail-compilation/link-referenced-from-main-function-ptr.c
@@ -1,0 +1,7 @@
+extern int f();
+
+int g(int (*fptr)()) { return (*fptr)(); }
+
+int h() { return f(); }
+
+int main(void) { return g(&h); }

--- a/tests/unit-fail-compilation/link-referenced-from-main-function-ptr.c.ref
+++ b/tests/unit-fail-compilation/link-referenced-from-main-function-ptr.c.ref
@@ -6,4 +6,4 @@ link-referenced-from-main-function-ptr.c:1:1: error: No definition for symbol wi
         see CERT-C section MSC15-C http://rvdoc.org/CERT-C/MSC15-C
         see MISRA-C section 8.1:3 http://rvdoc.org/MISRA-C/8.1
 
-Translation failed (kcc_config dumped). To repeat, run this command in directory c-semantics:
+Translation failed (kcc_config dumped). To repeat, run this command in directory unit-fail-compilation:

--- a/tests/unit-fail-compilation/link-referenced-from-main-function-ptr.c.ref
+++ b/tests/unit-fail-compilation/link-referenced-from-main-function-ptr.c.ref
@@ -1,0 +1,9 @@
+link-referenced-from-main-function-ptr.c:1:1: error: No definition for symbol with external linkage: f.
+
+    Undefined behavior (UB-TDR2):
+        see C11 section 6.9:5 http://rvdoc.org/C11/6.9
+        see C11 section J.2:1 item 84 http://rvdoc.org/C11/J.2
+        see CERT-C section MSC15-C http://rvdoc.org/CERT-C/MSC15-C
+        see MISRA-C section 8.1:3 http://rvdoc.org/MISRA-C/8.1
+
+Translation failed (kcc_config dumped). To repeat, run this command in directory c-semantics:

--- a/tests/unit-fail-compilation/link-referenced-from-main-indirect.c
+++ b/tests/unit-fail-compilation/link-referenced-from-main-indirect.c
@@ -1,0 +1,5 @@
+extern int f();
+
+int g() { return f(); }
+
+int main(void) { return g(); }

--- a/tests/unit-fail-compilation/link-referenced-from-main-indirect.c.ref
+++ b/tests/unit-fail-compilation/link-referenced-from-main-indirect.c.ref
@@ -1,0 +1,9 @@
+link-referenced-from-main-indirect.c:1:1: error: No definition for symbol with external linkage: f.
+
+    Undefined behavior (UB-TDR2):
+        see C11 section 6.9:5 http://rvdoc.org/C11/6.9
+        see C11 section J.2:1 item 84 http://rvdoc.org/C11/J.2
+        see CERT-C section MSC15-C http://rvdoc.org/CERT-C/MSC15-C
+        see MISRA-C section 8.1:3 http://rvdoc.org/MISRA-C/8.1
+
+Translation failed (kcc_config dumped). To repeat, run this command in directory unit-fail-compilation:

--- a/tests/unit-fail-compilation/link-referenced-not-from-main.c
+++ b/tests/unit-fail-compilation/link-referenced-not-from-main.c
@@ -1,0 +1,5 @@
+extern int f();
+
+int g() { return f(); }
+
+int main(void) { return 0; }

--- a/tests/unit-pass/incompleteStruct-link1.c
+++ b/tests/unit-pass/incompleteStruct-link1.c
@@ -1,0 +1,5 @@
+extern struct foo x;
+void bar(struct foo *x);
+struct foo * const p = &x;
+
+int main() { bar(p); }

--- a/tests/unit-pass/incompleteStruct-link2.c
+++ b/tests/unit-pass/incompleteStruct-link2.c
@@ -1,0 +1,4 @@
+struct foo { int y; } x;
+void bar(struct foo *p) {
+  int *p2 = (int *)p;
+}

--- a/tests/unit-pass/link-not-referenced.c
+++ b/tests/unit-pass/link-not-referenced.c
@@ -1,0 +1,3 @@
+extern int f();
+
+int main(void) { return 0; }


### PR DESCRIPTION
If a symbol is not indirectly used by main, we should not require it to be defined. Implemented only for C.