### PR TITLE
remove overloaded ExprLoc

### DIFF
--- a/clang-tools/ClangKast/GetKastVisitor.h
+++ b/clang-tools/ClangKast/GetKastVisitor.h
@@ -62,7 +62,7 @@ public:
 
     if (Expr *E = dyn_cast<Expr>(S)) {
       if (!dyn_cast<CXXDefaultArgExpr>(S)) {
-        Kast::add(Kast::KApply("ExprLoc", Sort::EXPRLOC, {Sort::CABSLOC, Sort::EXPR}));
+        Kast::add(Kast::KApply("ExprLoc", Sort::EXPRLOC, {Sort::CABSLOC, Sort::KITEM}));
         CabsLoc(E->getExprLoc());
       }
     }

--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -575,6 +575,8 @@ module CPP-DYNAMIC-OTHER-SYNTAX
 
      syntax KItem ::= seqstrict(StrictList) [klabel(seqstrictcpp)]
 
+     syntax Bool ::= isSpuriousExpr(KItem) [function]
+
 endmodule // CPP-DYNAMIC-OTHER-SYNTAX
 
 module CPP-DYNAMIC-OTHER
@@ -1075,6 +1077,14 @@ module CPP-DYNAMIC-OTHER
      rule idOf(Class(_, X::CId, _)) => X
 
      rule idOf(_ :: S::ClassSpecifier) => idOf(S)
+
+     rule isSpuriousExpr(ExprLoc(_, X::KItem) => X)
+
+     rule isSpuriousExpr(X::KItem) => true
+          requires notBool isExpr(X)
+
+     rule isSpuriousExpr(E:Expr) => false
+          requires ExprLoc(...) :/=K E
 
 endmodule // CPP-DYNAMIC-OTHER
 

--- a/semantics/cpp/language/common/syntax.k
+++ b/semantics/cpp/language/common/syntax.k
@@ -193,11 +193,9 @@ module CPP-SYNTAX
      syntax Expr ::= ConvertType(CPPType, Expr)
                    | ExprLoc
 
-     syntax ExprLoc ::= ExprLoc(CabsLoc, Expr)
+     syntax ExprLoc ::= ExprLoc(CabsLoc, KItem)
 
-     syntax Init ::= ExprLoc(CabsLoc, Init)
-
-     syntax BraceInit ::= ExprLoc(CabsLoc, BraceInit)
+     syntax Init ::= ExprLoc
 
      syntax Block ::= BlockStmt(List)
                     | BlockStmt(Int, List)

--- a/semantics/cpp/language/execution/expr/expr-loc.k
+++ b/semantics/cpp/language/execution/expr/expr-loc.k
@@ -10,7 +10,7 @@ module CPP-EXECUTION-EXPR-EXPRLOC
      imports C-CONFIGURATION
      imports CPP-DYNAMIC-SYNTAX // Execution()
 
-     rule <k> ExprLoc(L::CabsLoc, E::Expr) => #ExecExprLoc(L, E) ...</k>
+     rule <k> ExprLoc(L::CabsLoc, E:Expr) => #ExecExprLoc(L, E) ...</k>
           <curr-program-loc> _ => L </curr-program-loc>
           requires Execution()
 

--- a/semantics/cpp/language/translation/decl/declarator.k
+++ b/semantics/cpp/language/translation/decl/declarator.k
@@ -417,7 +417,7 @@ module CPP-TRANSLATION-DECL-DECLARATOR
 
      syntax CPPType ::= completeDeclaration(CPPType, Init) [function]
 
-     rule completeDeclaration(T::CPPType, (ExprLoc(_, I::Init) => I))
+     rule completeDeclaration(T::CPPType, (ExprLoc(_, I:Init) => I))
 
      // @ref n4296 8.5.4:3.2 (char x[] = {"foo"})
      rule completeDeclaration(t(Q::Quals, Mods::Set, incompleteArrayType(t(Q'::Quals, Mods'::Set, T:CPPSimpleCharType))), BraceInit(ListItem(StringLiteral(Narrow::CharKind, S::String)))) => t(Q, Mods, arrayType(t(Q', Mods', T), lengthString(S) +Int 1))
@@ -441,11 +441,11 @@ module CPP-TRANSLATION-DECL-DECLARATOR
 
      rule completeDeclaration(t(Q::Quals, Mods::Set, incompleteArrayType(T::CPPType)), BraceInit(ListItem(Init::Init) L::List)) => t(Q, Mods, arrayType(T, size(L) +Int 1))
           requires (size(L) =/=Int 0 orBool StringLiteral(...) :/=K Init)
-               andBool (notBool isAggregateType(T) orBool isBraceInit(Init))
+               andBool (notBool isAggregateType(T) orBool #isBraceInit(Init))
 
      rule completeDeclaration(t(Q::Quals, Mods::Set, incompleteArrayType(t(... st: classType(...)) #as T::CPPType)), BraceInit((ListItem(Init::Init) _) #as L::List)) => t(Q, Mods, arrayType(T, computeAggArraySize(getClassInfo(T), L)))
           requires isAggregateType(T)
-               andBool notBool isBraceInit(Init)
+               andBool notBool #isBraceInit(Init)
 
      rule completeDeclaration(T::CPPType, _) => T [owise]
 
@@ -465,7 +465,7 @@ module CPP-TRANSLATION-DECL-DECLARATOR
                            types: (F |-> (_::CPPType |-> (T::CPPType, _))) _,
                            initList: (ListItem(Init::Expr) => .List) _
                            )
-          requires (notBool isAggregateType(T) orBool isBraceInit(Init))
+          requires (notBool isAggregateType(T) orBool #isBraceInit(Init))
 
      rule #computeAggArraySize(...
                            fields: (ListItem(Class.DataMember(F:CId, _)) Fields::List => Class.getNonStaticDataMembers(getClassInfo(T))),
@@ -474,7 +474,7 @@ module CPP-TRANSLATION-DECL-DECLARATOR
                            callStack: (.List => ListItem(kpair(Fields, Types))) _
                            )
           requires isAggregateType(T)
-               andBool notBool isBraceInit(Init)
+               andBool notBool #isBraceInit(Init)
 
      syntax Decl ::= lazyDefineObject(NNSVal, CId, CId, CPPType, Init, DeclarationType, Set, SymBase)
 

--- a/semantics/cpp/language/translation/decl/initializer.k
+++ b/semantics/cpp/language/translation/decl/initializer.k
@@ -79,9 +79,11 @@ module CPP-TRANSLATION-DECL-INITIALIZER
 
      context defaultInit(HOLE:Expr, _, _) [result(LVal)]
 
-     context #figureInit(... srcT: HOLE:TypeExpr => typeof(HOLE)) [result(CPPType)]
+     context #figureInit(... srcT: HOLE:TypeExpr => typeof(HOLE))
+          requires notBool isSpuriousExpr(HOLE) [result(CPPType)]
 
-     context #figureInit(... srcCat: HOLE:CatExpr => catof(HOLE)) [result(ValueCategory)]
+     context #figureInit(... srcCat: HOLE:CatExpr => catof(HOLE))
+          requires notBool isSpuriousExpr(HOLE) [result(ValueCategory)]
 
      rule <k> #figureInit(Base::Expr, DestT::CPPType, IType::InitType,
                I::Init, SrcType::CPPType, SrcCat::ValueCategory,
@@ -102,7 +104,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
 
      syntax KItem ::= #figureInitHeatBase(destT: CPPType, type: InitType, init: Init, srcT: K, srcCat: K, ConstructorType, Duration)
 
-     rule <k> #figureInit(... init: ExprLoc(L::CabsLoc, I::Init) => I) ...</k>
+     rule <k> #figureInit(... init: ExprLoc(L::CabsLoc, I:Init) => I) ...</k>
           <curr-tr-program-loc> _ => L </curr-tr-program-loc>
 
      // @ref n4296 8.5:6.1
@@ -225,6 +227,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
      // @ref n4296 8.5:17.2 (reference destination type)
      rule #figureInit(Base:LVal, cppRefType #as DestT::CPPType, _, E:Expr, _, _, _, D::Duration)
           => bindReference(Base, E, D)
+          requires ExprLoc(...) :/=K E
 
      // @ref n4296 8.5:17.3 (string literal)
      rule #figureInit(Base:LVal, t(... st: _:CPPSimpleArrayType) #as DestT::CPPType, _, StringLiteral(Kind::CharKind, S::String), _, _, _, _)
@@ -239,7 +242,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
      // @ref n4296 8.5:17.6.1 (direct init or copy init from derived class)
      rule #figureInit(Base:LVal, t(... st: classType(DestC::Class)) #as DestT::CPPType, Type::InitType, E:Expr, SrcT::CPPType, _, IsConstructor::ConstructorType, _)
           => constructorInit(Base, Type, DestC, ListItem(E), IsConstructor)
-          requires Type ==K DirectInit() orBool (isCPPClassType(SrcT) andBool isBaseClassOf(DestT, SrcT))
+          requires ExprLoc(...) :/=K E andBool (Type ==K DirectInit() orBool (isCPPClassType(SrcT) andBool isBaseClassOf(DestT, SrcT)))
 
      rule #figureInit(Base:LVal, t(... st: classType(DestC::Class)), DirectInit(), ExpressionList(L::List), _, _, IsConstructor::ConstructorType, _)
           => constructorInit(Base, DirectInit(), DestC, L, IsConstructor)
@@ -249,7 +252,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
      // expression initializer, non-class type
      rule #figureInit(Base:LVal, DestT::CPPType, _, E:Expr, SrcT:CPPType, SrcCat:ValueCategory, _, _)
           => #if canConvertWithStandardConversion(DestT, SrcT, SrcCat) #then le(Base, trace(Base), DestT) :=init E #else ill-formed #fi
-          requires notBool isCPPRefType(DestT) andBool notBool isCPPArrayType(DestT) andBool notBool isCPPClassType(DestT) andBool notBool isCPPClassType(SrcT)
+          requires ExprLoc(...) :/=K E andBool  notBool isCPPRefType(DestT) andBool notBool isCPPArrayType(DestT) andBool notBool isCPPClassType(DestT) andBool notBool isCPPClassType(SrcT)
 
      rule #figureInit(... base: lv(loc(Base::SymBase, _), _, _), init: S:Stmt)
           => functionDef(Base, S)
@@ -368,7 +371,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
                            initializers: (F |-> (_::CPPType |-> (T::CPPType, _))) _,
                            class: C::Class,
                            duration: D::Duration)
-          requires (notBool isAggregateType(T) orBool isBraceInit(Init))
+          requires (notBool isAggregateType(T) orBool #isBraceInit(Init))
 
      rule (.K => #figureInit0(Base . no-template Name(C, F), T,
                     CopyInit(), BraceInit(L), ConstructorInit(false), D))
@@ -379,7 +382,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
                            class: C::Class,
                            duration: D::Duration)
           requires isAggregateType(T)
-           andBool notBool isBraceInit(Init)
+           andBool notBool #isBraceInit(Init)
 
      rule (classAggInit(... fields: .List, initList: L::List, initExp: E2::MaybeExpr) => .K)
           ~> classAggInit(... initList: .List => L, initExp: E1::MaybeExpr => compoundInitJoin(E1, E2))
@@ -414,7 +417,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
 
      rule #evalBraceOrEqualInitializer(_, _, NoInit()) => BraceInit(.List)
 
-     rule #evalBraceOrEqualInitializer(_, _, ExprLoc(L::CabsLoc, I::Init) => I)
+     rule #evalBraceOrEqualInitializer(_, _, ExprLoc(L::CabsLoc, I:Init) => I)
 
      rule #evalBraceOrEqualInitializer(C::Class, Base::Expr, BraceInit(L::List))
        => BraceInit(#evalBraceOrEqualInitializers(C, Base, L))
@@ -467,7 +470,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
                current:  I::Int,
                initList: ListItem(Init::Init) _
           )
-          requires (notBool isAggregateType(T) orBool isBraceInit(Init))
+          requires (notBool isAggregateType(T) orBool #isBraceInit(Init))
            andBool Size >Int I
 
      rule (.K => braceElisionMaybe(Init, T)) ~>
@@ -476,7 +479,7 @@ module CPP-TRANSLATION-DECL-INITIALIZER
                current:  I::Int,
                initList: (ListItem(Init::Init) _) #as L::List
           )
-          requires notBool isBraceInit(Init)
+          requires notBool #isBraceInit(Init)
            andBool isAggregateType(T)
            andBool Size >Int I
 
@@ -489,9 +492,11 @@ module CPP-TRANSLATION-DECL-INITIALIZER
      // If the initializer is neither BraceInit nor Expr, then this rule may not apply.
      rule braceElisionMaybe(E:Expr, T::CPPType) => braceElisionMaybe2(E, E, E, T)
 
-     context braceElisionMaybe2(... initType: (HOLE:TypeExpr => typeof(HOLE))) [result(CPPDType)]
+     context braceElisionMaybe2(... initType: (HOLE:TypeExpr => typeof(HOLE)))
+          requires notBool isSpuriousExpr(HOLE) [result(CPPDType)]
 
-     context braceElisionMaybe2(... initCat: (HOLE:CatExpr => catof(HOLE))) [result(ValueCategory)]
+     context braceElisionMaybe2(... initCat: (HOLE:CatExpr => catof(HOLE)))
+          requires notBool isSpuriousExpr(HOLE) [result(ValueCategory)]
 
      rule braceElisionMaybe2(...
                init:     From::Expr,

--- a/semantics/cpp/language/translation/expr/conditional.k
+++ b/semantics/cpp/language/translation/expr/conditional.k
@@ -44,9 +44,9 @@ module CPP-TRANSLATION-EXPR-CONDITIONAL
 
      syntax KItem ::= typeAndCatOfConditional(Expr, TypeExpr, CatExpr, Expr, TypeExpr, CatExpr) [klabel(typeAndCatOfConditional0)]
 
-     rule typeAndCatOfConditional(ExprLoc(_, E::Expr) => E, _)
+     rule typeAndCatOfConditional(ExprLoc(_, E:Expr) => E, _)
 
-     rule typeAndCatOfConditional(_, ExprLoc(_, E::Expr) => E)
+     rule typeAndCatOfConditional(_, ExprLoc(_, E:Expr) => E)
 
      rule typeAndCatOfConditional(E1::Expr, E2::Expr) => typeAndCatOfConditional(E1, E1, E1, E2, E2, E2) [owise]
 

--- a/semantics/cpp/language/translation/init.k
+++ b/semantics/cpp/language/translation/init.k
@@ -76,7 +76,7 @@ module CPP-TRANSLATION-INIT
           <curr-program-loc> _ => L </curr-program-loc>
           requires Execution()
 
-     rule <k> ExprLoc(L::CabsLoc, E::Expr) => #ExprLoc(L, E) ...</k>
+     rule <k> ExprLoc(L::CabsLoc, E:Expr) => #ExprLoc(L, E) ...</k>
           <curr-tr-program-loc> _ => L </curr-tr-program-loc>
           requires Translation()
 

--- a/semantics/cpp/language/translation/name.k
+++ b/semantics/cpp/language/translation/name.k
@@ -379,7 +379,7 @@ module CPP-TRANSLATION-NAME
 
      rule (.K => argDependentNameLookup(X, Args)) ~> CallExpr(Name(NoNNS(), X::CId), Args::StrictList, krlist(.List))
 
-     rule <k> CallExpr((ExprLoc(L::CabsLoc, E::Expr) => E), Args::StrictList, krlist(.List)) ...</k>
+     rule <k> CallExpr((ExprLoc(L::CabsLoc, E:Expr) => E), Args::StrictList, krlist(.List)) ...</k>
           <curr-tr-program-loc> _ => L </curr-tr-program-loc>
 
      context CallExpr(Name(HOLE:NNS, _), _, _)
@@ -431,7 +431,7 @@ module CPP-TRANSLATION-NAME
      context & HOLE:Expr
              requires notBool isName(HOLE) andBool notBool isExprLoc(HOLE)
 
-     rule <k> & (ExprLoc(L::CabsLoc, E::Expr) => E) ...</k>
+     rule <k> & (ExprLoc(L::CabsLoc, E:Expr) => E) ...</k>
           <curr-tr-program-loc> _ => L </curr-tr-program-loc>
 
      rule ElaboratedTypeSpecifier(T::Tag, X::CId, NoNNS()) => resolveElabSpecifier(T, nameLookup(X, T, typeMask))

--- a/semantics/cpp/language/translation/syntax.k
+++ b/semantics/cpp/language/translation/syntax.k
@@ -271,9 +271,7 @@ module CPP-ABSTRACT-SYNTAX
                        | UTF16() [symbol]
                        | UTF32() [symbol]
 
-     syntax BraceInit ::= BraceInit(List) [symbol]
-
-     syntax Init ::= BraceInit
+     syntax Init ::= BraceInit(List) [symbol]
 
      syntax ExpressionList ::= ExpressionList(List) [symbol]
 
@@ -292,6 +290,8 @@ module CPP-ABSTRACT-SYNTAX
      syntax Init ::= ConstructorCall(Bool, AType, List) [symbol]
 
      syntax AStmt ::= StmtLoc(CabsLoc, AStmt) [symbol]
+
+     syntax Bool ::= "#isBraceInit" "(" KItem ")" [function]
 
 endmodule
 
@@ -314,7 +314,7 @@ module CPP-TRANSLATION-ABSTRACT-REWRITING
 
      syntax Bool ::= hasAnonymousUnionObject(Expr) [function]
 
-     rule hasAnonymousUnionObject(ExprLoc(_, E::Expr) => E)
+     rule hasAnonymousUnionObject(ExprLoc(_, E:Expr) => E)
 
      rule hasAnonymousUnionObject(Name(NoNNS(), #NoName)) => true
 
@@ -344,5 +344,11 @@ module CPP-TRANSLATION-ABSTRACT-REWRITING
      rule DestructorTypeId(Name(NoNNS(), X::CId)) => DestructorId(X) [anywhere]
 
      context IfTStmt((HOLE:Expr => reval(HOLE)), _, _) [result(PRVal)]
+
+     rule #isBraceInit(ExprLoc(_, X::KItem) => X)
+
+     rule #isBraceInit(BraceInit(_)) => true
+
+     rule #isBraceInit(_) => false [owise]
 
 endmodule

--- a/semantics/cpp/language/translation/typing/expr.k
+++ b/semantics/cpp/language/translation/typing/expr.k
@@ -71,13 +71,14 @@ module CPP-TRANSLATION-TYPING-EXPR
 
      syntax KResult ::= NoInitType
 
-     context (HOLE:TypeExpr => typeof(HOLE)) types:: _ [result(CPPDType)]
+     context (HOLE:TypeExpr => typeof(HOLE)) types:: _
+          requires notBool isSpuriousExpr(HOLE) [result(CPPDType)]
 
      context K:KResult types:: HOLE:STypeList
 
      // ----------------------------------
 
-     rule typeof(ExprLoc(_, E::Expr) => E)
+     rule typeof(ExprLoc(_, E:Expr) => E)
 
      rule typeof(StringLiteral(Ascii(), S::String) => type(arrayType(const(char), lengthString(S) +Int 1)))
 

--- a/semantics/cpp/language/translation/value-category.k
+++ b/semantics/cpp/language/translation/value-category.k
@@ -64,13 +64,14 @@ module CPP-TRANSLATION-VALUE-CATEGORY
 
      rule (NoInit() => NoInitCat()) cats:: _
 
-     context (HOLE:CatExpr => catof(HOLE)) cats:: _ [result(ValueCategory)]
+     context (HOLE:CatExpr => catof(HOLE)) cats:: _
+          requires notBool isSpuriousExpr(HOLE) [result(ValueCategory)]
 
      context K:KResult cats:: HOLE:SCatList
 
      // --------------------------------
 
-     rule catof(ExprLoc(_, E::Expr) => E)
+     rule catof(ExprLoc(_, E:Expr) => E)
 
      rule catof(StringLiteral(_, _) => lvalue)
 


### PR DESCRIPTION
so that the parser to Kore does not need to choose the right overload