### PR TITLE
Sync llvm backend and add rverror K implementation

### DIFF
--- a/clang-tools/ClangKast/ClangKast.cc
+++ b/clang-tools/ClangKast/ClangKast.cc
@@ -330,7 +330,7 @@ void Kast::add(const T & node) {
   Kast::Nodes.push_back(make_unique<T>(node));
 }
 
-void Kast::print() { print(Sort::K, 0); }
+void Kast::print() { print(Sort::KITEM, 0); }
 
 int Kast::print(Sort parentSort, int idx) {
   if (!Nodes[idx]) throw logic_error("parse error");

--- a/semantics/c/language/execution/error.k
+++ b/semantics/c/language/execution/error.k
@@ -6,7 +6,7 @@ module C-EXECUTION-ERROR-SYNTAX
      imports C-DYNAMIC-SORTS
      imports ERROR-SYNTAX
 
-     syntax List ::= printStackTrace(List, String, Scope, CabsLoc, Map) [function, hook(C_SEMANTICS.printStackTrace)]
+     syntax List ::= printStackTrace(List, String, Scope, CabsLoc, Map) [function]
 endmodule
 
 module C-EXECUTION-ERROR

--- a/semantics/c/language/execution/error.k
+++ b/semantics/c/language/execution/error.k
@@ -6,7 +6,7 @@ module C-EXECUTION-ERROR-SYNTAX
      imports C-DYNAMIC-SORTS
      imports ERROR-SYNTAX
 
-     syntax String ::= printStackTrace(List, String, Scope, CabsLoc, Map) [function, hook(C_SEMANTICS.printStackTrace)]
+     syntax List ::= printStackTrace(List, String, Scope, CabsLoc, Map) [function, hook(C_SEMANTICS.printStackTrace)]
 endmodule
 
 module C-EXECUTION-ERROR
@@ -28,6 +28,6 @@ module C-EXECUTION-ERROR
           <renv> REnv::Map </renv>
 
      // this rule prevents the open source semantics from getting stuck on this function
-     rule printStackTrace(_, _, _, _, _) => ""
+     rule printStackTrace(_, _, _, _, _) => .List
 
 endmodule

--- a/semantics/c/language/execution/io.k
+++ b/semantics/c/language/execution/io.k
@@ -2,6 +2,7 @@ module C-IO-SYNTAX
      imports INT-SYNTAX
      imports LIST
      imports MAP
+     imports MEMORY-SORTS
      imports SYMLOC-SORTS
 
      syntax KItem ::= realloc(SymBase, SymBase, Int, Int)

--- a/semantics/c/language/execution/io.k
+++ b/semantics/c/language/execution/io.k
@@ -5,6 +5,7 @@ module C-IO-SYNTAX
      imports SYMLOC-SORTS
 
      syntax KItem ::= realloc(SymBase, SymBase, Int, Int)
+     syntax Bits ::= getUninitializedBits(SymLoc, EffectiveType) [function]
 
 endmodule
 
@@ -261,7 +262,6 @@ module C-IO
              dataList(Aux)
           [structural]
 
-     syntax Bits ::= getUninitializedBits(SymLoc, EffectiveType) [function]
      rule getUninitializedBits(L::SymLoc, _) => piece(trap, cfg:bitsPerByte)
           requires notBool (isStaticDuration(L) orBool isThreadDuration(L))
      rule getUninitializedBits(L::SymLoc, dynamicType(T::Type))

--- a/semantics/common/configuration.k
+++ b/semantics/common/configuration.k
@@ -6,6 +6,9 @@ module COMMON-CONFIGURATION
   imports STRING-SYNTAX
   imports COMMON-SYNTAX
 
+  syntax Enum ::= DummyEnum()
+  syntax Class ::= DummyClass()
+
   configuration
   <global>
      <mem> .Map </mem>
@@ -101,7 +104,7 @@ module COMMON-CONFIGURATION
 
                <classes color="lightgray">
                     <class multiplicity="*" type="Map">
-                         <class-id> .K </class-id>
+                         <class-id> DummyClass() </class-id>
                          <class-type> .K </class-type>
                          <is-aggregate> true </is-aggregate>
                          <base-classes> .List </base-classes>
@@ -127,7 +130,7 @@ module COMMON-CONFIGURATION
 
                <cpp-enums>
                     <cppenum multiplicity="*" type="Map">
-                         <enum-id> .K </enum-id>
+                         <enum-id> DummyEnum() </enum-id>
                          <enum-type> .K </enum-type>
                          <scoped> false </scoped>
                          <enumerators> .Map </enumerators>

--- a/semantics/common/error.k
+++ b/semantics/common/error.k
@@ -7,7 +7,7 @@ module ERROR-SYNTAX
      syntax ErrorMsg ::= ErrorMsg(ErrorCategory, String, String, List)
                        | ErrorMsg(ErrorCategory, String, String) [function, klabel(ErrorMsgS)]
 
-     syntax ErrorTrace ::= errorTrace(String, String)
+     syntax ErrorTrace ::= errorTrace(String, List)
 
      syntax K ::= reportError(ErrorMsg, tu: String, Scope, CabsLoc, Map, K) [function, hook(C_SEMANTICS.error)]
 

--- a/semantics/common/error.k
+++ b/semantics/common/error.k
@@ -9,7 +9,7 @@ module ERROR-SYNTAX
 
      syntax ErrorTrace ::= errorTrace(String, List)
 
-     syntax K ::= reportError(ErrorMsg, tu: String, Scope, CabsLoc, Map, K) [function, hook(C_SEMANTICS.error)]
+     syntax K ::= reportError(ErrorMsg, tu: String, Scope, CabsLoc, Map, K) [function]
 
      syntax ErrorCategory ::= Undef(LanguageLinkage) | Unspec(LanguageLinkage) | Impl(LanguageLinkage) | ImplUB(LanguageLinkage) | Cond() | Ill() | Drafting(LanguageLinkage) | Constraint() | Syntax(LanguageLinkage)
      syntax KItem ::= EXIT(ErrorMsg)

--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -286,6 +286,7 @@ module CPP-QUALID-SYNTAX
 
      syntax CId ::= getId(QualId) [function]
 
+     syntax QualId ::= toQualId(Enum) [function]
 endmodule // CPP-QUALID-SYNTAX
 
 module CPP-QUALID
@@ -294,6 +295,9 @@ module CPP-QUALID
     rule getId(_ :: X::CId) => X
 
     rule getQual(N::NNSVal :: _) => N
+
+    rule toQualId(N:Namespace :: Enum(X)) => N :: X
+    rule toQualId(C:Class :: Enum(X)) => C :: X
 
 endmodule // CPP-QUALID
 

--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -291,13 +291,14 @@ endmodule // CPP-QUALID-SYNTAX
 
 module CPP-QUALID
      imports CPP-QUALID-SYNTAX // self
+     imports CPP-DYNAMIC-OTHER-SYNTAX
 
-    rule getId(_ :: X::CId) => X
+     rule getId(_ :: X::CId) => X
 
-    rule getQual(N::NNSVal :: _) => N
+     rule getQual(N::NNSVal :: _) => N
 
-    rule toQualId(N:Namespace :: Enum(X)) => N :: X
-    rule toQualId(C:Class :: Enum(X)) => C :: X
+     rule toQualId(N:Namespace :: Enum(X)) => N :: X
+     rule toQualId(C:Class :: Enum(X)) => C :: X
 
 endmodule // CPP-QUALID
 

--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -273,8 +273,8 @@ module CPP-QUALID-SYNTAX
      imports CPP-QUALID-SORTS // self
      imports CPP-SORTS // CId, Name
 
-     syntax NNS ::= NoNNS()
-                  | NNS "::" NNSSpecifier [klabel(NestedName)]
+     syntax NNS ::= NoNNS() [symbol]
+                  | NNS "::" NNSSpecifier [klabel(NestedName), symbol]
 
      syntax NNSSpecifier ::= NNS(CId)
                            | TemplateNNS(CId)

--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -292,6 +292,7 @@ endmodule // CPP-QUALID-SYNTAX
 module CPP-QUALID
      imports CPP-QUALID-SYNTAX // self
      imports CPP-DYNAMIC-OTHER-SYNTAX
+     imports CPP-CLASS-BASIC-SYNTAX
 
      rule getId(_ :: X::CId) => X
 

--- a/semantics/cpp/language/translation/decl/initializer.k
+++ b/semantics/cpp/language/translation/decl/initializer.k
@@ -329,13 +329,13 @@ module CPP-TRANSLATION-DECL-INITIALIZER
 
      syntax Bool ::= hasInit(CId, Map) [function]
 
-     rule hasInit(X:CId, X |-> M::Map _) => notBool isNoInit(M)
+     rule hasInit(X:CId, X |-> M::Map _) => notBool hasNoInit(M)
 
-     syntax Bool ::= isNoInit(Map) [function]
+     syntax Bool ::= hasNoInit(Map) [function]
 
-     rule isNoInit(_ |-> (_, NoInit())) => true
+     rule hasNoInit(_ |-> (_, NoInit())) => true
 
-     rule isNoInit(_ |-> _) => false [owise]
+     rule hasNoInit(_ |-> _) => false [owise]
 
      syntax Expr ::= classAggInit(base: LVal, fields: List, initList: List, initializers: Map, class: Class, initExp: K, ctype: ConstructorType, duration: Duration)
 

--- a/semantics/cpp/language/translation/name.k
+++ b/semantics/cpp/language/translation/name.k
@@ -261,7 +261,7 @@ module CPP-TRANSLATION-NAME
           <enumerators>... X |-> V::PRVal </enumerators>
           requires variable in Mask
 
-     rule <k> lookupEnumerator(X::CId, E::Enum, Mask::Set, C:K) => #if C ==K .K #then prv(V, Tr, ET) #else classSet(prv(V, Tr, ET), {C}:>Class :: X, SetItem({C}:>Class)) #fi ... </k>
+     rule <k> lookupEnumerator(X::CId, E::Enum, Mask::Set, C:K) => #if C ==K .K #then {prv(V, Tr, ET)}:>KItem #else {classSet(prv(V, Tr, ET), {C}:>Class :: X, SetItem({C}:>Class))}:>KItem #fi ... </k>
           <curr-tr-scope> Sc::Scope </curr-tr-scope>
           <enum-id> E </enum-id>
           <enum-type> ET::CPPType </enum-type>

--- a/semantics/cpp/language/translation/syntax.k
+++ b/semantics/cpp/language/translation/syntax.k
@@ -191,7 +191,7 @@ module CPP-ABSTRACT-SYNTAX
                    | ForTStmt(Stmt, Decl, Stmt, Stmt)
                    | ForTStmt(Expr, Stmt, Stmt)
                    | TemplateDefinitionStmt(K) [symbol] // synthetic statement created by the body of a function template definition when it's evaluted before instantiation
-                   | TReturnOp(init: Expr, obj: K)
+                   | TReturnOp(init: Expr, obj: K) [symbol]
 
      syntax AStmt ::= NoStatement() [symbol]
                     | CompoundAStmt(List) [symbol]


### PR DESCRIPTION
I am trying to get all my K code dealing with error reporting merged upstream, and that means getting the semantics in master as close to what it is in the llvm backend as possible. So we sync the remaining differences from the lastest branch and also append some (but not all) of the changes to the c semantics relating to error reporting.