### PR TITLE
Remove some instances of the `[structural]` attribute on contexts

### DIFF
--- a/semantics/cpp/language/common/dynamic.k
+++ b/semantics/cpp/language/common/dynamic.k
@@ -555,8 +555,6 @@ module CPP-DYNAMIC-OTHER-SYNTAX
 
      syntax KResult ::= ValResult
 
-     syntax KItem ::= resolve(Expr)
-
      // used by destructors
      syntax KItem ::= addToConstructed(Expr, CPPType) [strict(c; 1)]
 
@@ -1045,8 +1043,6 @@ module CPP-DYNAMIC-OTHER
                false,
                .List
              )
-
-     context resolve(HOLE:Expr) [result(ResolvedExpr), structural]
 
      rule cat(prv(...)) => prvalue
 

--- a/semantics/cpp/language/translation/decl/class.k
+++ b/semantics/cpp/language/translation/decl/class.k
@@ -584,7 +584,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
      rule checkCtorAndDtor(K:K, X::CId, T::CPPType, B::Bool, _, t(... st: classType(M::Class)))
           => checkDtor(M) ~> figureConstructItem(K, X, T, B) [owise]
 
-     rule <k> (.K => resolve(resolveOverload(cSet(Candidates, M :: ConstructorId(X)), list(.List), constructor)))
+     rule <k> (.K => resolveOverload(cSet(Candidates, M :: ConstructorId(X)), list(.List), constructor))
               ~> checkCtor(_ :: Class(_, X::CId, _) #as M::Class)
           ...</k>
           <curr-tr-tu> Tu::String </curr-tr-tu>
@@ -592,10 +592,9 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <class-id> M </class-id>
           <cenv>... ConstructorId(X) |-> Candidates::Map ...</cenv>
 
-     rule resolve(E:ResolvedExpr) ~> checkCtor(_) => .K
-          requires notBool isNotFoundNameRef(E)
+     rule resolveOverloadResult(E:ResolvedExpr) ~> checkCtor(_) => .K
 
-     rule <k> (.K => resolve(checkAccess(CallExpr(lv(lnew(Base), hasTrace(Name(NoNNS(), DestructorId(X))), T), list(.List), krlist(.List)))))
+     rule <k> (.K => checkAccess(CallExpr(lv(lnew(Base), hasTrace(Name(NoNNS(), DestructorId(X))), T), list(.List), krlist(.List))))
               ~> checkDtor(_ :: Class(_, X::CId, _) #as M::Class)
           ...</k>
           <curr-tr-tu> Tu::String </curr-tr-tu>
@@ -603,8 +602,7 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <class-id> M </class-id>
           <cenv>... DestructorId(X) |-> (_::CPPType |-> (T::CPPType, envEntry(... base: Base::SymBase))) ...</cenv>
 
-     rule resolve(E:ResolvedExpr) ~> checkDtor(_) => .K
-          requires notBool isNotFoundNameRef(E)
+     rule resolveOverloadResult(E:ResolvedExpr) ~> checkDtor(_) => .K
 
      syntax Bool  ::= isDeletedDefaultConstructor(CId, CPPType, Class, CPPType, Set, Init) [function]
 
@@ -880,11 +878,10 @@ syntax Stmt ::= Defaulted(SpecialMemberFunction, Class) [klabel(DefaultedSMF)]
           <functions>... Base |-> functionObject(_, FuncT::CPPType, _, _) ...</functions>
           requires isMethodVirtual(FuncT)
 
-     rule (cSet(... candidates: Cands::Map, id: Q::QualId) #as C:CandidateSet => resolve(resolveOverload(C, list(ListItem(prv(NullPointer, noTrace, type(pointerType(type(void))))) getSecondDeleteArg(Cands, prv(0, noTrace, type(size_t)))), Name(NoNNS(), operatordelete))))
+     rule (cSet(... candidates: Cands::Map, id: Q::QualId) #as C:CandidateSet => resolveOverload(C, list(ListItem(prv(NullPointer, noTrace, type(pointerType(type(void))))) getSecondDeleteArg(Cands, prv(0, noTrace, type(size_t)))), Name(NoNNS(), operatordelete)))
           ~> figureDestruct(...)
 
-     rule resolve(E:ResolvedExpr) ~> figureDestruct(.List, .List, Res:K) => Res
-          requires notBool isNotFoundNameRef(E)
+     rule resolveOverloadResult(E:ResolvedExpr) ~> figureDestruct(.List, .List, Res:K) => Res
 
      syntax KItem ::= TaddToConstructed(Expr, CPPType) [strict(c; 1)]
 

--- a/semantics/cpp/language/translation/decl/initializer.k
+++ b/semantics/cpp/language/translation/decl/initializer.k
@@ -575,7 +575,8 @@ module CPP-TRANSLATION-DECL-INITIALIZER
      // *** </ Aggregate initialization of an array >
 
 
-     rule <k> (.K => resolveOverload(cSet(#if Type ==K DirectInit() #then M #else stripExplicit(M) #fi, C :: ConstructorId(X)), list(L), constructor))
+     rule <k> (.K => resolveOverload(cSet(#if Type ==K DirectInit() #then M #else stripExplicit(M) #fi, C :: ConstructorId(X)), list(L), constructor)
+              ~> stripResolveOverloadResult())
               ~> constructorInit(Base::LVal, Type::InitType, _ :: Class(_, X::CId, _) #as C::Class, L::List, _)
           ...</k>
           <curr-tr-tu> Tu::String </curr-tr-tu>

--- a/semantics/cpp/language/translation/expr/members.k
+++ b/semantics/cpp/language/translation/expr/members.k
@@ -4,6 +4,8 @@ module CPP-TRANSLATION-EXPR-MEMBERS
      imports CPP-SYNTAX
      imports CPP-ABSTRACT-SYNTAX
      imports CPP-DYNAMIC-SYNTAX
+     imports CPP-TRANSLATION-OVERLOADING-SYNTAX
+     imports CPP-TRANSLATION-OPERATORS-SYNTAX
 
      rule <k> This() => Obj ...</k>
           <tr-this> Obj::Expr </tr-this>
@@ -11,7 +13,15 @@ module CPP-TRANSLATION-EXPR-MEMBERS
 
      context CallExpr(HOLE:Expr . _ _, _, _)
 
-     context CallExpr(BinaryOperator(operator->, _, _) #as HOLE:Expr, _, _) [result(ResolvedExpr), structural]
+     syntax KItem ::= CallExprOpArrowFreezer(StrictList, StrictListResult)
+
+     rule CallExpr(BinaryOperator(operator->, _, _) #as E::Expr, S::StrictList, R::StrictListResult)
+          => resolveBinaryOperator(E)
+          ~> CallExprOpArrowFreezer(S, R)
+
+     rule resolveOverloadResult(E:ResolvedExpr)
+          ~> CallExprOpArrowFreezer(S::StrictList, R::StrictListResult)
+          => CallExpr(E, S, R)
 
      rule fieldExp(E:GLExpr, T::CPPType, Offset::Int)
           => makeExpr(cat(E), fieldExp(E, T, Offset), trace(E), T)

--- a/semantics/cpp/language/translation/expr/new.k
+++ b/semantics/cpp/language/translation/expr/new.k
@@ -49,12 +49,14 @@ module CPP-TRANSLATION-EXPR-NEW
 
      rule (cSet(... id: Q::QualId) #as C:CandidateSet => resolveOverload(C, list(ListItem(pre(newSize(!I), noTrace, type(size_t)) * prv(byteSizeofType(T), noTrace, type(size_t))) P),
                                              Name(NoNNS(), operatornew[]))
+          ~> stripResolveOverloadResult()
           ~> !I:Int)
           ~> NewExpr(_, T::CPPType, _, _, P::List)
           requires getId(Q) ==K operatornew[]
 
      rule (cSet(... id: Q::QualId) #as C:CandidateSet => resolveOverload(C, list(ListItem(prv(byteSizeofType(T), noTrace, type(size_t))) P),
-                                                                          Name(NoNNS(), operatornew)))
+                                                                          Name(NoNNS(), operatornew))
+          ~> stripResolveOverloadResult())
           ~> NewExpr(_, T:CPPType, _, _, P::List)
           requires getId(Q) ==K operatornew
 
@@ -156,6 +158,7 @@ module CPP-TRANSLATION-EXPR-NEW
                  ),
                  Name(NoNNS(), operatordelete)
                )
+            ~> stripResolveOverloadResult()
             ~> !I:Int
           )
           ~> DeleteExpr(_, false, V::PRVal)

--- a/semantics/cpp/language/translation/name.k
+++ b/semantics/cpp/language/translation/name.k
@@ -10,6 +10,7 @@ module CPP-TRANSLATION-NAME-SYNTAX
      syntax Expr ::= nameLookup(CId, Tag, mask: Set)
                    | qualifiedNameLookup(CId, NNS, mask: Set)
 
+     // evaluates to `resolveOverloadResult(_)`
      syntax Expr ::= resolveOverloadedOperator(OpId, Expr, TypeExpr)
                    | resolveOverloadedOperator(OpId, Expr, TypeExpr, Init, K)
 
@@ -20,6 +21,7 @@ module CPP-TRANSLATION-NAME-SYNTAX
                   | "namespaceMask" [function]
                   | "nnsMask" [function]
                   | "typeMask" [function]
+
 endmodule
 
 module CPP-TRANSLATION-NAME
@@ -396,6 +398,7 @@ module CPP-TRANSLATION-NAME
 
      rule cSet(Y::Map, X::QualId) ~> CallExpr(E::Expr, Args::StrictList, krlist(.List))
           => resolveOverload(cSet(Y, X), Args, E)
+          ~> stripResolveOverloadResult()
 
      rule (.K => qualifiedNameLookup(X, C, defaultMask)) ~> (lv(_, _, t(... st: classType(C::Class))) #Or xv(_, _, t(... st: classType(C::Class))) #Or prv(_, _, t(... st: classType(C::Class)))) . no-template Name(NoNNS(), X::CId)
 
@@ -748,24 +751,29 @@ module CPP-TRANSLATION-NAME
 
      syntax Expr ::= resolveEmptyOverload(CandidateSet, StrictList, Expr, Expr)
                    | resolveEmptyOverloadArrow(CandidateSet, StrictList, Expr, Expr, Name)
-                   | #resolveEmptyOverload(Expr, Expr, K)
+                   | #resolveEmptyOverload(Expr, K)
 
      rule resolveEmptyOverload(C::CandidateSet, Args::StrictList, Builtin::Expr, E::Expr)
-          => #resolveEmptyOverload(resolveOverload(C, Args, E), Builtin, .K)
+          => resolveOverload(C, Args, E) ~> #resolveEmptyOverload(Builtin, .K)
 
      rule resolveEmptyOverloadArrow(C::CandidateSet, Args::StrictList, Builtin::Expr, E::Expr, N::Name)
-          => #resolveEmptyOverload(resolveOverload(C, Args, E), Builtin, N)
+          => resolveOverload(C, Args, E) ~> #resolveEmptyOverload(Builtin, N)
 
-     context #resolveEmptyOverload(HOLE:Expr, _, _) [result(ResolvedExpr), structural]
 
-     rule #resolveEmptyOverload(E:ResolvedExpr, _, .K) => E
+     rule resolveOverloadResult(E:ResolvedExpr)
+          ~> #resolveEmptyOverload(_, .K)
+          => resolveOverloadResult(E)
           requires notBool isNotFoundNameRef(E)
 
-     rule #resolveEmptyOverload(E:ResolvedExpr, _, N:Name) => BinaryOperator(operator->, E, N)
+     rule resolveOverloadResult(E:ResolvedExpr)
+          ~> #resolveEmptyOverload(_, N:Name)
+          => resolveOverloadResult(BinaryOperator(operator->, E, N))
           requires notBool isNotFoundNameRef(E)
 
      // no viable candidates
-     rule #resolveEmptyOverload(notFound(_), E::Expr, _) => E
+     rule notFound(_)
+          ~> #resolveEmptyOverload(E::Expr, _)
+          => resolveOverloadResult(E)
 
      rule addBuiltinCandidates(O::OpId, E1::Expr, T1::CPPType, _, E2::Expr, T2::CPPType, _, C1:CandidateSet, C2:CandidateSet)
           => resolveOverload(cSetUnion2(C1, cSetUnion2(C2, builtinCandidates(O, T1, T2, C2, builtinOperator(O, E1, E2)))), list(ListItem(E1) ListItem(E2)), BinaryOperator(O, E1, E2))

--- a/semantics/cpp/language/translation/operators.k
+++ b/semantics/cpp/language/translation/operators.k
@@ -10,6 +10,7 @@ module CPP-TRANSLATION-OPERATORS
      imports CPP-ABSTRACT-SYNTAX
      imports CPP-SYNTAX
      imports CPP-TRANSLATION-NAME-SYNTAX
+     imports CPP-TRANSLATION-OVERLOADING-SYNTAX
      imports CPP-TRANSLATION-TYPING-EXPR-SYNTAX
      imports CPP-TYPING-SYNTAX
 
@@ -40,6 +41,7 @@ module CPP-TRANSLATION-OPERATORS
 
      rule #BinaryOperator(O::OpId, E1::Expr, T1:CPPType, E2::Init, T2:CPPType)
           => resolveOverloadedOperator(O, E1, T1, E2, T2)
+          ~> stripResolveOverloadResult()
           requires isCPPClassType(T1) orBool isCPPClassType(T2)
                orBool isCPPEnumType(T1) orBool isCPPEnumType(T2)
 
@@ -49,6 +51,7 @@ module CPP-TRANSLATION-OPERATORS
 
      rule #UnaryOperator(O::OpId, E1::Expr, T1:CPPDType)
           => resolveOverloadedOperator(O, E1, T1)
+          ~> stripResolveOverloadResult()
           requires isCPPClassType(T1) orBool isCPPEnumType(T1)
 
 

--- a/semantics/cpp/language/translation/operators.k
+++ b/semantics/cpp/language/translation/operators.k
@@ -2,6 +2,9 @@ module CPP-TRANSLATION-OPERATORS-SYNTAX
      imports CPP-SORTS
      syntax Expr ::= builtinOperator(OpId, Expr, Init) [function]
                    | builtinOperator(OpId, Expr) [function, klabel(builtinOperator2)]
+
+     // takes BinaryOperator, rewrites to `resolveOverloadResult(_)`
+     syntax KItem ::= resolveBinaryOperator(Expr)
 endmodule
 
 module CPP-TRANSLATION-OPERATORS
@@ -13,8 +16,13 @@ module CPP-TRANSLATION-OPERATORS
      imports CPP-TRANSLATION-OVERLOADING-SYNTAX
      imports CPP-TRANSLATION-TYPING-EXPR-SYNTAX
      imports CPP-TYPING-SYNTAX
+     imports C-CONFIGURATION
 
-     rule BinaryOperator(O::OpId, E1::Expr, E2::Init)
+     rule BinaryOperator(_,_,_) #as BO:Expr
+          => resolveBinaryOperator(BO)
+          ~> stripResolveOverloadResult()
+
+     rule resolveBinaryOperator(BinaryOperator(O::OpId, E1::Expr, E2::Init))
           => #BinaryOperator(O, E1, E1, E2, E2)
 
      rule UnaryOperator(O::OpId, E1::Expr)
@@ -31,17 +39,16 @@ module CPP-TRANSLATION-OPERATORS
      context #UnaryOperator(_, _, (HOLE:TypeExpr => typeof(HOLE))) [result(CPPDType)]
 
      rule #BinaryOperator(operator->, E1::Expr, T1:CPPType, E2::Init, _)
-          => builtinOperator(operator->, E1, E2)
+          => resolveOverloadResult(builtinOperator(operator->, E1, E2))
           requires notBool isCPPClassType(T1) andBool notBool isCPPEnumType(T1)
 
      rule #BinaryOperator(O::OpId, E1::Expr, T1:CPPType, E2::Init, T2:CPPType)
-          => builtinOperator(O, E1, E2)
+          => resolveOverloadResult(builtinOperator(O, E1, E2))
           requires notBool isCPPClassType(T1) andBool notBool isCPPClassType(T2)
                andBool notBool isCPPEnumType(T1) andBool notBool isCPPEnumType(T2)
 
      rule #BinaryOperator(O::OpId, E1::Expr, T1:CPPType, E2::Init, T2:CPPType)
           => resolveOverloadedOperator(O, E1, T1, E2, T2)
-          ~> stripResolveOverloadResult()
           requires isCPPClassType(T1) orBool isCPPClassType(T2)
                orBool isCPPEnumType(T1) orBool isCPPEnumType(T2)
 

--- a/semantics/cpp/language/translation/overloading.k
+++ b/semantics/cpp/language/translation/overloading.k
@@ -9,12 +9,14 @@ module CPP-TRANSLATION-OVERLOADING-SYNTAX
 
      syntax CandidateSet ::= cSet(candidates: Map, id: QualId)
 
+     // evaluates to `resolveOverloadResult(_)` or `notFound(_)`
      syntax Expr ::= resolveOverload(CandidateSet, StrictList, Expr)
                    | resolveConversionOverload(CandidateSet, StrictList, Expr, CPPType)
                    | resolveRefConversionOverload(CandidateSet, StrictList, Expr, CPPType)
-                   | resolveUniqueDecl(KItem, Expr, Bool) [strict(1)]
-                   | cSetUnion(KItem, KItem) [strict]
                    | checkAccess(Expr)
+
+     syntax Expr ::= resolveUniqueDecl(KItem, Expr, Bool) [strict(1)]
+                   | cSetUnion(KItem, KItem) [strict]
 
      // not a real expression, but getArgs understands it.
      syntax Expr ::= "constructor"
@@ -24,6 +26,9 @@ module CPP-TRANSLATION-OVERLOADING-SYNTAX
      syntax BuiltinOp ::= builtinOp(Expr)
 
      syntax KItem ::= canBeImplicitlyConvertedTo(fromType: CPPType, fromCat: ValueCategory, toType: CPPType)
+
+     syntax KItem ::= resolveOverloadResult(KItem)
+                    | stripResolveOverloadResult()
 endmodule
 
 module CPP-TRANSLATION-OVERLOADING
@@ -52,8 +57,12 @@ module CPP-TRANSLATION-OVERLOADING
      imports CPP-TRANSLATION-VALUE-CATEGORY-SYNTAX
      imports ERROR-SYNTAX
 
+     rule resolveOverloadResult(X)
+          ~> stripResolveOverloadResult()
+          => X
+
      // access checking stub (not implemented yet)
-     rule checkAccess(E::Expr) => E
+     rule checkAccess(E::Expr) => resolveOverloadResult(E)
 
      syntax Expr ::= resolveOverloadWithType(CandidateSet, StrictList, Expr, OverloadType)
 
@@ -612,7 +621,8 @@ module CPP-TRANSLATION-OVERLOADING
           ~> updateExternalUses(Base)
           ~> checkAccess(CallExpr(lv(lnew(Base), hasTrace(E), T), list(Args), DArgs))
 
-     rule bestViable(T::CPPType, builtinOp(E::Expr)) ~> #resolveOverload2(...) => E
+     rule bestViable(T::CPPType, builtinOp(E::Expr)) ~> #resolveOverload2(...)
+          => resolveOverloadResult(E)
 
      rule (.K => computeBestViable(M, Types, Cats, O))
           ~> #resolveOverload2(cSet(... candidates: M::Map), list(Args::List), krlist(Types::List), krlist(Cats::List), _, O::OverloadType)

--- a/semantics/cpp/language/translation/typing/expr.k
+++ b/semantics/cpp/language/translation/typing/expr.k
@@ -28,6 +28,7 @@ module CPP-TRANSLATION-TYPING-EXPR
      imports CPP-CLASS-SYNTAX
      imports CPP-CONVERSION-SYNTAX
      imports CPP-TRANSLATION-EXPR-CONDITIONAL-SYNTAX
+     imports CPP-TRANSLATION-OVERLOADING-SYNTAX
      imports CPP-SYMLOC-SYNTAX
      imports CPP-SYNTAX
      imports CPP-TRANSLATION-NAME-SYNTAX
@@ -228,12 +229,16 @@ module CPP-TRANSLATION-TYPING-EXPR
           requires isCPPClassType(T1) orBool isCPPClassType(T2)
                orBool isCPPEnumType(T1) orBool isCPPEnumType(T2)
 
-     // these contexts require the structural attribute to ensure that they always apply prior to the rules
-     // for evaluating expressions. Otherwise we might evaluate too far even though this expression
-     // is not potentially evaluated in this context.
-     context typeof(resolveOverloadedOperator(_, _, _) #as HOLE:Expr) [result(ResolvedExpr), structural]
+     rule typeof(resolveOverloadedOperator(_, _, _) #as X:Expr)
+          => X ~> typeofResolveOverloadedOperatorFreezer()
 
-     context typeof(resolveOverloadedOperator(_, _, _, _, _) #as HOLE:Expr) [result(ResolvedExpr), structural]
+     rule typeof(resolveOverloadedOperator(_, _, _, _, _) #as X:Expr)
+          => X ~> typeofResolveOverloadedOperatorFreezer()
+
+     rule resolveOverloadResult(X:Expr) ~> typeofResolveOverloadedOperatorFreezer()
+          => typeof(X)
+
+     syntax KItem ::= typeofResolveOverloadedOperatorFreezer()
 
      rule typeofBuiltinOperator(O::OpId, T1:CPPDType, E::Expr, T2:CPPDType)
           => #typeofBuiltinOperator(O, T1, E, T2)

--- a/semantics/cpp/language/translation/value-category.k
+++ b/semantics/cpp/language/translation/value-category.k
@@ -26,6 +26,7 @@ module CPP-TRANSLATION-VALUE-CATEGORY
      imports CPP-TRANSLATION-EXPR-CONDITIONAL-SYNTAX
      imports CPP-SYNTAX
      imports CPP-TRANSLATION-NAME-SYNTAX
+     imports CPP-TRANSLATION-OVERLOADING-SYNTAX
      imports CPP-TRANSLATION-TYPING-EXPR-SYNTAX
      imports CPP-TYPING-SYNTAX
 
@@ -191,12 +192,16 @@ module CPP-TRANSLATION-VALUE-CATEGORY
           requires isCPPClassType(T1) orBool isCPPClassType(T2)
                orBool isCPPEnumType(T1) orBool isCPPEnumType(T2)
 
-     // these contexts require the structural attribute to ensure that they always apply prior to the rules
-     // for evaluating expressions. Otherwise we might evaluate too far even though this expression
-     // is not potentially evaluated in this context.
-     context catof(resolveOverloadedOperator(_, _, _) #as HOLE:Expr) [result(ResolvedExpr), structural]
+     rule catof(resolveOverloadedOperator(_, _, _) #as X:Expr)
+          => X ~> catofResolveOverloadedOperatorFreezer()
 
-     context catof(resolveOverloadedOperator(_, _, _, _, _) #as HOLE:Expr) [result(ResolvedExpr), structural]
+     rule catof(resolveOverloadedOperator(_, _, _, _, _) #as X:Expr)
+          => X ~> catofResolveOverloadedOperatorFreezer()
+
+     rule resolveOverloadResult(X:Expr) ~> catofResolveOverloadedOperatorFreezer()
+          => catof(X)
+
+     syntax KItem ::= catofResolveOverloadedOperatorFreezer()
 
      rule catofBuiltinOperator(O::OpId, T1:CPPDType, C:ValueCategory, T2:CPPDType)
           => #catofBuiltinOperator(O, T1, C, T2)


### PR DESCRIPTION
These instances could be replaced by higher priorityheat/cool rule pairs, but that is a problem in the LLVM backend.