### PR TITLE
Try to fix effective type of unions

### DIFF
--- a/semantics/c/language/common/expr/additive.k
+++ b/semantics/c/language/common/expr/additive.k
@@ -182,17 +182,17 @@ module C-COMMON-EXPR-ADDITIVE
      rule newFromArray(Loc:SymLoc, _, _) => Loc
           requires notBool isFromArray(Loc)
 
-     rule #newFromArray(Base:SymBase, Offset:Int, fromArray(ArrOffset:Int, Len:Int),
+     rule #newFromArray(Base:SymBase, Offset:Int, fromArray(ArrOffset:Int, Len:Int, Eff::EffectiveType),
                .Set, Prov:Set, T::UType, I:Int)
           => loc(Base, Offset, SetItem(
-               fromArray(ArrOffset +Int I *Int byteSizeofType(innerType(T)), Len)) Prov)
+               fromArray(ArrOffset +Int I *Int byteSizeofType(innerType(T)), Len, Eff)) Prov)
      rule #newFromArray(Base:SymBase, Offset:Int, K:KItem, .Set, Prov:Set, _, _)
           => loc(Base, Offset, SetItem(K) Prov)
           requires fromArray(...) :/=K K
-     rule #newFromArray(Base:SymBase, Offset:Int, fromArray(ArrOffset:Int, Len:Int),
+     rule #newFromArray(Base:SymBase, Offset:Int, fromArray(ArrOffset:Int, Len:Int, Eff::EffectiveType),
                SetItem(K':KItem) S:Set, Prov:Set, T::UType, I:Int)
           => #newFromArray(Base, Offset, K', S, SetItem(fromArray(ArrOffset +Int
-               I *Int byteSizeofType(innerType(T)), Len)) Prov, T, I)
+               I *Int byteSizeofType(innerType(T)), Len, Eff)) Prov, T, I)
      rule #newFromArray(Base:SymBase, Offset:Int, K:KItem, SetItem(K':KItem)
                S:Set, Prov:Set, T::UType, I:Int)
           => #newFromArray(Base, Offset, K', S, SetItem(K) Prov, T, I)

--- a/semantics/c/language/common/expr/eval.k
+++ b/semantics/c/language/common/expr/eval.k
@@ -74,7 +74,7 @@ module C-COMMON-EXPR-EVAL
 
      syntax KItem ::= lvalConvert(SymLoc, Type, KItem) [strict(3)]
      rule <k> lvalConvert(Loc::SymLoc, T::Type, LAT:EffectiveType)
-               => checkEffectiveType(T, bitOffset(Loc), LAT)
+               => checkEffectiveType(T, offset(Loc), bitOffsetIntoLastByte(Loc), getFromArray(Loc), LAT)
                // The new last access type becomes a composite of the current
                // last-access object type and the type of the current lvalue
                // expression.

--- a/semantics/c/language/common/expr/eval.k
+++ b/semantics/c/language/common/expr/eval.k
@@ -107,7 +107,7 @@ module C-COMMON-EXPR-EVAL
 
      syntax SymLoc ::= arrayToPtrLoc(SymLoc, Type) [function]
      rule arrayToPtrLoc(Loc::SymLoc, t(... st: _:SimpleFixedArrayType) #as T::Type)
-          => addProv(fromArray(0, byteSizeofType(T)), Loc)
+          => addProv(fromArray(0, byteSizeofType(T), T), Loc)
      rule arrayToPtrLoc(Loc::SymLoc, _) => Loc [owise]
 
      /*@ \fromStandard{\source[n1570]{\para{6.3.2.1}{4}}}{

--- a/semantics/c/language/common/expr/reference.k
+++ b/semantics/c/language/common/expr/reference.k
@@ -27,7 +27,7 @@ module C-COMMON-EXPR-REFERENCE
      }
      */
      rule &(nclv(Loc:SymLoc, T::Type))
-          => checkUse(tv(addProv(fromArray(0, byteSizeofType(T)), Loc),
+          => checkUse(tv(addProv(fromArray(0, byteSizeofType(T), T), Loc),
                utype(pointerType(T))))
           requires notBool isRegisterLoc(Loc)
                andBool notBool isBitfieldType(T)

--- a/semantics/c/language/common/symloc.k
+++ b/semantics/c/language/common/symloc.k
@@ -47,11 +47,11 @@ module C-SYMLOC
           requires notBool isFromArray(Loc)
 
      syntax Bool ::= #ifFromArrayInBounds(K, Set, UType, Int) [function]
-     rule #ifFromArrayInBounds(fromArray(Offset:Int, Len:Int), _, T::UType, I:Int)
+     rule #ifFromArrayInBounds(fromArray(Offset:Int, Len:Int, _), _, T::UType, I:Int)
           => true
           requires (Offset +Int (I *Int byteSizeofType(innerType(T))) >=Int 0)
                andBool (Offset +Int (I *Int byteSizeofType(innerType(T))) <=Int Len)
-     rule #ifFromArrayInBounds(fromArray(Offset:Int, Len:Int), _, T::UType, I:Int)
+     rule #ifFromArrayInBounds(fromArray(Offset:Int, Len:Int, _), _, T::UType, I:Int)
           => false
           requires (Offset +Int (I *Int byteSizeofType(innerType(T))) <Int 0)
                orBool (Offset +Int (I *Int byteSizeofType(innerType(T))) >Int Len)

--- a/semantics/c/language/common/typing/effective.k
+++ b/semantics/c/language/common/typing/effective.k
@@ -5,7 +5,7 @@ module C-TYPING-EFFECTIVE-SYNTAX
      imports C-TYPING-SORTS
      imports SYMLOC-SORTS
 
-     syntax K ::= checkEffectiveType(Type, Int, EffectiveType) [function]
+     syntax K ::= checkEffectiveType(Type, Int, Int, K, EffectiveType) [function]
      syntax KItem ::= adjustPointerBounds(RValue)
 
      syntax KItem ::= getLastAccessType(SymLoc)

--- a/semantics/c/language/execution/check-effective.k
+++ b/semantics/c/language/execution/check-effective.k
@@ -21,15 +21,20 @@ module C-CHECK-EFFECTIVE
      // variants. When a write occurs through a SymLoc, its attached
      // last-access type becomes the effective type of the object.
 
-     rule checkEffectiveType(L::Type, Offset::Int, LAT:Type)
+     syntax K ::= #checkEffectiveType(Type, Int, EffectiveType) [function]
+     rule #checkEffectiveType(L::Type, Offset::Int, LAT:Type)
           => effTypeUB(L, LAT) ~> effectiveTypeViolation(L, Offset, LAT)
           requires notBool effectivelyCompat(L, getTypesAtOffset(LAT, Offset))
-     rule checkEffectiveType(L::Type, Offset::Int, dynamicType(LAT::Type))
+     rule #checkEffectiveType(L::Type, Offset::Int, dynamicType(LAT::Type))
           => effTypeUB(L, LAT) ~> effectiveTypeViolation(L, Offset, dynamicType(LAT))
           requires notBool (effectivelyCompat(L, getTypesAtOffset(LAT, Offset))
                orBool effectivelyCompat(LAT, getTypesAtOffset(L, Offset))
                orBool isNoType(LAT))
-     rule checkEffectiveType(_, _, _) => .K [owise]
+     rule #checkEffectiveType(...) => .K [owise]
+     rule checkEffectiveType(L::Type, ByteOffset::Int, BitOffset::Int, fromArray(FromArrayOffset::Int, _, LAT::EffectiveType), _)
+          => checkEffectiveType(L, FromArrayOffset, BitOffset, .K, LAT)
+     rule checkEffectiveType(L::Type, ByteOffset::Int, BitOffset::Int, .K, LAT::EffectiveType)
+          => #checkEffectiveType(L, ByteOffset *Int cfg:bitsPerByte +Int BitOffset, LAT)
 
      syntax KItem ::= effectiveTypeViolation(Type, Int, EffectiveType)
      syntax KItem ::= effTypeUB(Type, Type) [function]

--- a/semantics/c/language/execution/check-effective.k
+++ b/semantics/c/language/execution/check-effective.k
@@ -65,8 +65,8 @@ module C-CHECK-EFFECTIVE
           [owise]
 
      syntax SymLoc ::= adjustBounds(SymLoc, Type) [function]
-     rule adjustBounds(loc(_, _, SetItem(fromArray(_, N::Int)) _) #as Loc::SymLoc, T::Type)
-          => addProv(fromArray(0, byteSizeofType(T)), stripFromArray(Loc))
+     rule adjustBounds(loc(_, _, SetItem(fromArray(_, N::Int, _)) _) #as Loc::SymLoc, T::Type)
+          => addProv(fromArray(0, byteSizeofType(T), T), stripFromArray(Loc))
           requires byteSizeofType(T) >Int N
      // TODO(chathhorn): only allow adjusting the size up for now (because we
      // need to be able to distinguish a pointer into an array of T from a

--- a/semantics/c/language/execution/check-effective.k
+++ b/semantics/c/language/execution/check-effective.k
@@ -55,10 +55,10 @@ module C-CHECK-EFFECTIVE
      syntax RValue ::= "adjustPointerBounds'" "(" SymLoc "," UType "," Type "," EffectiveType ")" [function]
      rule adjustPointerBounds'(Loc::SymLoc, T::UType, T'::Type, t(...) #as Eff::Type)
           => tv(adjustBounds(Loc, T'), T)
-          requires notBool isCharType(T') andBool effectivelyCompat(T', getTypesAtOffset(Eff, offset(Loc)))
+          requires notBool isCharType(T') andBool effectivelyCompat(T', getTypesAtOffset(Eff, bitOffset(Loc)))
      rule adjustPointerBounds'(Loc::SymLoc, T::UType, T'::Type, dynamicType(Eff::Type))
           => tv(adjustBounds(Loc, T'), T)
-          requires notBool isCharType(T') andBool (effectivelyCompat(T', getTypesAtOffset(Eff, offset(Loc)))
+          requires notBool isCharType(T') andBool (effectivelyCompat(T', getTypesAtOffset(Eff, bitOffset(Loc)))
                orBool effectivelyCompat(Eff, getTypesAtOffset(T', offset(Loc))))
      rule adjustPointerBounds'(Loc::SymLoc, T::UType, _, _)
           => tv(Loc, T)

--- a/semantics/c/language/execution/stmt/expr.k
+++ b/semantics/c/language/execution/stmt/expr.k
@@ -60,13 +60,13 @@ module C-STMT-EXPR
           requires notBool isFromArray(Loc)
 
      rule checkArrayStaticAssign'(T:Type,
-               arrayStatic(N:Int), fromArray(Offset:Int, Sz:Int))
+               arrayStatic(N:Int), fromArray(Offset:Int, Sz:Int, _))
           => .K
           requires (Sz -Int Offset) >=Int (N *Int byteSizeofType(T))
      rule (.K => UNDEF("EEA5",
                "Passing a pointer to an array object of fewer elements than required by a function parameter with a static-qualified array size."))
           ~> checkArrayStaticAssign'(T:Type,
-               arrayStatic(N:Int), fromArray(Offset:Int, Sz:Int))
+               arrayStatic(N:Int), fromArray(Offset:Int, Sz:Int, _))
           requires (Sz -Int Offset) <Int (N *Int byteSizeofType(T))
 
      syntax Modifier ::= getArrayStatic(Set) [function]

--- a/semantics/c/language/translation/io.k
+++ b/semantics/c/language/translation/io.k
@@ -64,7 +64,7 @@ module C-IO
      rule readBytes'(_, 0, Aux:List) => dataList(Aux)
           [structural]
 
-     rule checkEffectiveType(_, _, _) => .K
+     rule checkEffectiveType(...) => .K
      rule adjustPointerBounds(V::RValue) => V
 
 endmodule

--- a/semantics/c/library/stdlib.k
+++ b/semantics/c/library/stdlib.k
@@ -76,7 +76,7 @@ module LIBC-STDLIB
 
      rule <k> alignedAlloc(Align::Int, Sz::Int)
                => alloc(obj(!I:Int, Align, alloc), type(no-type), Sz)
-               ~> tv(addProv(fromArray(0, Sz), lnew(obj(!I, Align, alloc))),
+               ~> tv(addProv(fromArray(0, Sz, dynamicType(type(no-type))), lnew(obj(!I, Align, alloc))),
                     utype(pointerType(type(void))))
           ...</k>
           <malloced>... .Map => obj(!I, Align, alloc) |-> Sz ...</malloced>
@@ -113,9 +113,10 @@ module LIBC-STDLIB
      rule [realloc]:
           <k> builtin("realloc", tv(loc(OldBase:SymBase, 0), _), tv(NewLen:Int, _))
                => realloc(OldBase, bnew(!I:Int, type(no-type), alloc), OldLen, NewLen)
-               ~> tv(loc(bnew(!I, type(no-type), alloc), 0, SetItem(fromArray(0, NewLen))),
+               ~> tv(loc(bnew(!I, type(no-type), alloc), 0, SetItem(fromArray(0, NewLen, T))),
                     utype(pointerType(type(void))))
           ...</k>
+          <mem>... OldBase |-> object(T::EffectiveType, _, _) ...</mem>
           <malloced>...
                (OldBase => bnew(!I, type(no-type), alloc)) |-> (OldLen:Int => NewLen)
           ...</malloced>

--- a/semantics/common/symloc.k
+++ b/semantics/common/symloc.k
@@ -7,6 +7,7 @@ endmodule
 
 module SYMLOC-SYNTAX
      imports SYMLOC-SORTS
+     imports MEMORY-SORTS
      imports LIST
      imports COMPAT-SYNTAX
 
@@ -103,7 +104,7 @@ module SYMLOC-SYNTAX
      // Pointers from an array need to be checked that they don't go out of
      // bounds of that array, even if that array happens to be part of a larger
      // object (i.e., surrounded by valid addresses).
-     syntax Provenance ::= fromArray(Int, Int)
+     syntax Provenance ::= fromArray(Int, Int, EffectiveType)
 
      syntax Bool ::= isFromArray(SymLoc) [function]
 
@@ -360,7 +361,7 @@ module SYMLOC
      rule showProvSet(SetItem(P:KItem) Prov::Set) => ", " +String showK(P) +String showProvSet(Prov) [owise]
 
      syntax String ::= showProvenance(Provenance) [function]
-     rule showProvenance(fromArray(A::Int, B::Int)) => "array" +String wrapParens(showInt(A) +String ", " +String showInt(B))
+     rule showProvenance(fromArray(A::Int, B::Int, _)) => "array" +String wrapParens(showInt(A) +String ", " +String showInt(B))
      rule showProvenance(basedOn(B::SymBase, _)) => "based" +String wrapParens(showSymBase(B))
      rule showProvenance(objectType(T::EffectiveType)) => showEffectiveType(T)
      rule showProvenance(P::Provenance) => showK(P) [owise]

--- a/semantics/cpp/language/common/conversion.k
+++ b/semantics/cpp/language/common/conversion.k
@@ -244,8 +244,8 @@ module CPP-CONVERSION
 
      syntax SymLoc ::= arrayToPtrLoc(SymLoc, CPPType) [function, klabel(arrayToPtrLocCpp)]
 
-     rule arrayToPtrLoc(Loc::SymLoc, t(_, _, arrayType(T::CPPType, N::Int)))
-          => addProv(fromArray(0, byteSizeofType(T) *Int N), Loc)
+     rule arrayToPtrLoc(Loc::SymLoc, t(_, _, arrayType(...)) #as T::CPPType)
+          => addProv(fromArray(0, byteSizeofType(T), T), Loc)
 
      rule arrayToPtrLoc(Loc::SymLoc, _) => Loc [owise]
 

--- a/semantics/cpp/language/common/expr/additive.k
+++ b/semantics/cpp/language/common/expr/additive.k
@@ -36,8 +36,8 @@ module CPP-EXPR-ADDITIVE
      rule newFromArray(Loc::SymLoc, T::CPPType, I::Int)
           => #newFromArray(Loc, getFromArray(Loc), byteSizeofType(innerType(T)) *Int I)
 
-     rule #newFromArray(Loc::SymLoc, fromArray(ArrOffset::Int, Len::Int), NewOffset::Int)
-          => addProv(fromArray(ArrOffset +Int NewOffset, Len), stripFromArray(Loc))
+     rule #newFromArray(Loc::SymLoc, fromArray(ArrOffset::Int, Len::Int, Eff::EffectiveType), NewOffset::Int)
+          => addProv(fromArray(ArrOffset +Int NewOffset, Len, Eff), stripFromArray(Loc))
 
      rule #newFromArray(Loc::SymLoc, .K, _) => Loc
 

--- a/semantics/cpp/language/common/symloc.k
+++ b/semantics/cpp/language/common/symloc.k
@@ -75,7 +75,7 @@ module CPP-SYMLOC
 
      rule ifFromArrayInBounds(Loc::SymLoc, T::CPPType, I::Int) => #ifFromArrayInBounds(getFromArray(Loc), byteSizeofType(innerType(T)) *Int I)
 
-     rule #ifFromArrayInBounds(fromArray(Offset::Int, Len::Int), NewOffset::Int) => Offset +Int NewOffset >=Int 0 andBool Offset +Int NewOffset <=Int Len
+     rule #ifFromArrayInBounds(fromArray(Offset::Int, Len::Int, _), NewOffset::Int) => Offset +Int NewOffset >=Int 0 andBool Offset +Int NewOffset <=Int Len
 
      rule #ifFromArrayInBounds(.K, _) => true
 

--- a/semantics/cpp/library/new.k
+++ b/semantics/cpp/library/new.k
@@ -15,7 +15,7 @@ module LIBCPP-NEW
 
      rule <k> builtin(GlobalNamespace() :: operatornew, prv(Len::Int, _, _))
               => allocObject(bnew(!I:Int, type(no-type), .Set, dynamic), type(no-type), Len)
-              ~> prv(addProv(fromArray(0, Len), lnew(bnew(!I, type(no-type), .Set, dynamic))), noTrace,
+              ~> prv(addProv(fromArray(0, Len, type(no-type)), lnew(bnew(!I, type(no-type), .Set, dynamic))), noTrace,
                    type(pointerType(type(void))))
           ...</k>
           <malloced>... .Map => bnew(!I, type(no-type), .Set, dynamic) |-> Len ...</malloced>


### PR DESCRIPTION
Essentially, we probably don't want to control effective typing based on the active variant of unions, because which variant is active doesn't really affect which object a pointer into the union points to... it's actually affected by which object the pointer was based on when you took the original address.

This is almost certainly not working yet, but I'm having difficulty getting the code to compile locally so I'm going to create a draft PR and examine the build result that way.