### PR TITLE
Handle fields with both tags and empty declarator lists

### DIFF
--- a/semantics/c/language/translation/decl/tagged.k
+++ b/semantics/c/language/translation/decl/tagged.k
@@ -278,6 +278,7 @@ module C-DECL-TAGGED
           => makeUnionFieldInfo'(Pack, L,
                Types, Offsets, NL)
        requires notBool isUnnamedStructOrUnionType(T)
+        andBool notBool isBitfieldType(T)
      rule makeUnionFieldInfo'(Pack::Bool,
                ListItem(typedDeclaration(T::Type, Field::CId)) L::List,
                Types::Map,
@@ -310,6 +311,7 @@ module C-DECL-TAGGED
                Offsets,
                NL)
        requires notBool isUnnamedStructOrUnionType(T)
+        andBool notBool isBitfieldType(T)
      rule makeStructFieldInfo'(Pack::Bool,
                ListItem(typedDeclaration(T::Type, Field::CId)) L::List,
                V::Int,

--- a/semantics/c/language/translation/decl/tagged.k
+++ b/semantics/c/language/translation/decl/tagged.k
@@ -245,10 +245,39 @@ module C-DECL-TAGGED
                orBool (tag(X, Tu, BlockNum) in_keys(Structs))
           [structural]
 
+     syntax Bool ::= isUnnamedStructOrUnionType(Type) [function]
+     rule isUnnamedStructOrUnionType( t( _,
+                                         _,
+                                         structType( tag ( I::CId,
+                                                           _,
+                                                           _ 
+                                                         ) 
+                                                   )
+                                       )
+                                    ) => isUnnamedCId(I)
+     rule isUnnamedStructOrUnionType( t( _,
+                                         _,
+                                         unionType( tag ( I::CId,
+                                                          _,
+                                                          _ 
+                                                        ) 
+                                                  )
+                                       )
+                                    ) => isUnnamedCId(I)
+     rule isUnnamedStructOrUnionType(T) => false [owise]
+
      rule makeUnionFieldInfo(Pack::Bool, Fs::List)
           => makeUnionFieldInfo'(Pack, Fs, .Map, .Map, .List)
 
      syntax FieldInfo ::= "makeUnionFieldInfo'" "(" Bool "," List "," Map ","  Map "," List ")" [function]
+     rule makeUnionFieldInfo'(Pack::Bool,
+               ListItem(typedDeclaration(T::Type, _:NoName)) L::List,
+               Types::Map,
+               Offsets::Map,
+               NL::List)
+          => makeUnionFieldInfo'(Pack, L,
+               Types, Offsets, NL)
+       requires notBool isUnnamedStructOrUnionType(T)
      rule makeUnionFieldInfo'(Pack::Bool,
                ListItem(typedDeclaration(T::Type, Field::CId)) L::List,
                Types::Map,
@@ -256,7 +285,7 @@ module C-DECL-TAGGED
                NL::List)
           => makeUnionFieldInfo'(Pack, L,
                Types[Field <- T], Offsets[Field <- 0],
-               NL ListItem(typedDeclaration(T, Field)))
+               NL ListItem(typedDeclaration(T, Field))) [owise]
      rule makeUnionFieldInfo'(true, .List, Types::Map, Offsets::Map, NL::List)
           => fieldInfo(NL, maxByteSizeofList(NL) *Int cfg:bitsPerByte, Types, Offsets, .Set, maxByteAlignofDecls(NL))
      rule makeUnionFieldInfo'(false, .List, Types::Map, Offsets::Map, NL::List)
@@ -264,11 +293,23 @@ module C-DECL-TAGGED
                roundBits(maxByteSizeofList(NL) *Int cfg:bitsPerByte, maxByteAlignofDecls(NL)),
                Types, Offsets, getPaddingOffsets(maxByteSizeofList(NL) *Int cfg:bitsPerByte, roundBits(maxByteSizeofList(NL) *Int cfg:bitsPerByte, maxByteAlignofDecls(NL))), maxByteAlignofDecls(NL))
 
-
      rule makeStructFieldInfo(Pack::Bool, Fs::List)
           => makeStructFieldInfo'(Pack, Fs, 0, .Map, .Map, .List)
 
      syntax FieldInfo ::= "makeStructFieldInfo'" "(" Bool "," List "," Int "," Map ","  Map "," List ")" [function]
+     rule makeStructFieldInfo'(Pack::Bool,
+               ListItem(typedDeclaration(T::Type, _:NoName)) L::List,
+               V::Int,
+               Types::Map,
+               Offsets::Map,
+               NL::List)
+          => makeStructFieldInfo'(Pack,
+               L,
+               V,
+               Types,
+               Offsets,
+               NL)
+       requires notBool isUnnamedStructOrUnionType(T)
      rule makeStructFieldInfo'(Pack::Bool,
                ListItem(typedDeclaration(T::Type, Field::CId)) L::List,
                V::Int,
@@ -280,7 +321,7 @@ module C-DECL-TAGGED
                pad(V, T) +Int bitSizeofType(T),
                Types[Field <- T],
                Offsets[Field <- pad(V, T)],
-               NL ListItem(typedDeclaration(T, Field)))
+               NL ListItem(typedDeclaration(T, Field))) [owise]
      rule makeStructFieldInfo'(true, .List, V::Int, Types::Map, Offsets::Map, NL::List)
           => fieldInfo(NL, roundBits(V, 1),
                Types, Offsets,

--- a/tests/unit-pass/struct-size-1.c
+++ b/tests/unit-pass/struct-size-1.c
@@ -1,0 +1,15 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+struct A {
+  uint16_t a;
+  union B {
+    uint16_t b;
+  };
+};
+
+int main() {
+  if(sizeof(struct A) != 2)
+      abort();
+  return 0;
+}

--- a/tests/unit-pass/struct-size-2.c
+++ b/tests/unit-pass/struct-size-2.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+struct A {
+  uint16_t a;
+  union B {
+    uint16_t b;
+  };
+  union B c;
+};
+
+int main() {
+  if(sizeof(struct A) != 4)
+      abort();
+  return 0;
+}

--- a/tests/unit-pass/union-size-1.c
+++ b/tests/unit-pass/union-size-1.c
@@ -1,0 +1,15 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+union A {
+  uint16_t a;
+  union B {
+    uint32_t b;
+  };
+};
+
+int main() {
+  if(sizeof(union A) != 2)
+      abort();
+  return 0;
+}

--- a/tests/unit-pass/union-size-2.c
+++ b/tests/unit-pass/union-size-2.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+union A {
+  uint16_t a;
+  union B {
+    uint32_t b;
+  };
+  union B c;
+};
+
+int main() {
+  if(sizeof(union A) != 4)
+      abort();
+  return 0;
+}


### PR DESCRIPTION
Ignore fields with both tags and empty declarator lists in structs and unions, when creating fields for structs and unions.

This is to address the problem (reported by DENSO) regarding difference in struct sizes computed by gcc/clang and kcc.
The struct's size was previously computed as 4 by kcc in the program Kevin provided (see below).
[pragmapack.c.txt](https://github.com/kframework/c-semantics/files/6126466/pragmapack.c.txt)

The added unit tests are modified versions of `pragmapack.c.txt`.